### PR TITLE
Pin standard.def deps via requirements-direct.txt (fixes #19)

### DIFF
--- a/containers/standard.def
+++ b/containers/standard.def
@@ -1,6 +1,9 @@
 Bootstrap: docker
 From: nvidia/cuda:12.9.1-cudnn-devel-ubuntu22.04
 
+%files
+    containers/requirements-direct.txt /opt/requirements-direct.txt
+
 %post
     chmod 1777 /tmp
     # Set environment variables
@@ -19,17 +22,24 @@ From: nvidia/cuda:12.9.1-cudnn-devel-ubuntu22.04
     # Create python3 symlink
     ln -sf /usr/bin/python3.10 /usr/bin/python3
     ln -sf /usr/bin/python3.10 /usr/bin/python
-    
+
     # Install Node.js (LTS version 22.x) for npm
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
     apt-get install -y nodejs
-    
+
     # Install uv
     curl -LsSf https://astral.sh/uv/install.sh | sh
     export PATH="/root/.local/bin:$PATH"
-    
+
+    # vllm first (controls torch/CUDA versions)
     uv pip install --system --no-cache vllm==0.11.0 --torch-backend=auto
-    
+
+    # Pinned direct dependencies (keeps inspect-ai / transformers / huggingface-hub in sync)
+    uv pip install --system --no-cache -r /opt/requirements-direct.txt
+
+    # flash-attn (needs no-build-isolation)
+    uv pip install --system --no-cache flash-attn==2.8.3 --no-build-isolation
+
     # Install AI CLI tools via npm
     npm install -g \
         @anthropic-ai/claude-code@2.0.55 \
@@ -37,31 +47,6 @@ From: nvidia/cuda:12.9.1-cudnn-devel-ubuntu22.04
         @google/gemini-cli@0.18.4 \
         opencode-ai@1.1.59
 
-    uv pip install --system --no-cache ninja packaging
-    
-    # Install the required packages
-    uv pip install --system --no-cache \
-        accelerate \
-        boto3 \
-        bitsandbytes \
-        datasets \
-        evaluate \
-        lm-eval \
-        openai \
-        pandas \
-        scikit-learn \
-        shortuuid \
-        tokenizers \
-        transformers \
-        trl \
-        peft \
-        tiktoken \
-        inspect-ai \
-        matplotlib \
-        certifi
-
-    uv pip install --system --no-cache flash_attn --no-build-isolation
-    
     # install inspect evals
     mkdir -p /opt
     cd /opt


### PR DESCRIPTION
## Summary

- Switches `containers/standard.def` to load `containers/requirements-direct.txt` instead of installing an unpinned package list inline
- Same pattern already used by `vllm_debug.def` and `opus_4_6_codex_5_3.def`, so `standard.def` now picks up the same pinned `inspect-ai==0.3.150`, `transformers==4.57.3`, and `huggingface-hub==0.36.0` that resolve cleanly together
- Pins `flash-attn==2.8.3` (was `flash_attn` unpinned) to match the working images

Fixes #19. As @hrdkbhatnagar noted in that thread, the maintainer-recommended pin is `inspect-ai==0.3.150`, which is what `requirements-direct.txt` already provides.

## Verification

All 20 packages from the previous inline install list are present in `containers/requirements-direct.txt`:

```
accelerate, boto3, bitsandbytes, datasets, evaluate, lm-eval, openai,
pandas, scikit-learn, shortuuid, tokenizers, transformers, trl, peft,
tiktoken, inspect-ai, matplotlib, certifi, ninja, packaging
```

Container behavior preserved otherwise:
- AI CLI tool versions for `standard.def` left unchanged (`claude-code@2.0.55`, `codex@0.79.0`, `gemini-cli@0.18.4`, `opencode-ai@1.1.59`)
- `inspect_evals` still cloned with `--depth=1` (no pinned commit), matching prior behavior of this image
- `%runscript`, `%environment`, `%labels`, `%help` blocks untouched

## Test plan

- [ ] `bash containers/build_container.sh standard` succeeds end-to-end
- [ ] In the built image, `python -c "import inspect_ai, transformers, huggingface_hub; print(inspect_ai.__version__, transformers.__version__, huggingface_hub.__version__)"` reports `0.3.150 / 4.57.3 / 0.36.0`
- [ ] `pip check` inside the image reports no resolver conflicts

(Re-opened from a clean fork; previous PR #46 closed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)