### PR TITLE
Make Harbor images Prime VM GPU capable

### DIFF
--- a/src/harbor_adapter/template/environment/Dockerfile
+++ b/src/harbor_adapter/template/environment/Dockerfile
@@ -1,8 +1,11 @@
-FROM nvidia/cuda:12.9.1-cudnn-devel-ubuntu22.04
+FROM primeintellect/nvidia-driver-images:590.48.01-cuda12.9-devel-ubuntu22.04-k6.16.9
 
 # This Dockerfile mirrors containers/opus_4_6_1m.def (the apptainer
 # image used by the HTCondor pipeline) for cross-environment parity.
 # Differences vs. apptainer build:
+#   - Prime VM sandboxes need a driver-aware guest image. Prime's CUDA
+#     base mirrors upstream CUDA while adding NVIDIA driver hotplug,
+#     Fabric Manager, and /dev/nvidia* initialization for VM GPUs.
 #   - --torch-backend=cu128 is explicit. Modal's build VM has no
 #     nvidia-smi/CUDA driver, so --torch-backend=auto would resolve to CPU
 #     torch and fail to satisfy vllm's CUDA-only xformers dependency.
@@ -90,5 +93,17 @@ RUN rm -f /home/agent/workspace/entrypoint.sh \
 
 RUN chmod -R a+rw /home/agent/workspace/ && \
     chmod +x /home/agent/workspace/timer.sh
+
+ENV PRIME_EXPECTED_GPU_COUNT=1
+ENV PRIME_EXPECTED_NVSWITCH_COUNT=0
+RUN sed -i \
+        -e 's/PRIME_EXPECTED_GPU_COUNT:-8/PRIME_EXPECTED_GPU_COUNT:-1/g' \
+        -e 's/PRIME_EXPECTED_NVSWITCH_COUNT:-4/PRIME_EXPECTED_NVSWITCH_COUNT:-0/g' \
+        /usr/local/bin/wait-for-nvidia-hotplug-topology \
+        /usr/local/bin/initialize-nvidia-gpu-stack && \
+    sed -i '/\/usr\/local\/bin\/start-nvidia-fabricmanager/i if [[ "${expected_switch_count}" == "0" ]]; then exit 0; fi' \
+        /usr/local/bin/initialize-nvidia-gpu-stack && \
+    sed -i '/# Wait for Fabric Manager to finish registering every GPU for NVSwitch fabrics\./i if [[ "${expected_switch_count}" == "0" ]]; then exit 0; fi' \
+        /usr/local/bin/initialize-nvidia-gpu-stack
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/harbor_adapter/template/environment/entrypoint.sh
+++ b/src/harbor_adapter/template/environment/entrypoint.sh
@@ -3,9 +3,10 @@
 #
 # Runs as PID 1 so its stdout is what Modal/Harbor stream live to the
 # sandbox dashboard. We:
-#   1. background `tail -F` of the agent and verifier log files so their
+#   1. initialize Prime VM NVIDIA devices
+#   2. background `tail -F` of the agent and verifier log files so their
 #      output flows through PID 1 stdout in real time
-#   2. start a system monitor daemon that writes GPU/CPU/memory stats to
+#   3. start a system monitor daemon that writes GPU/CPU/memory stats to
 #      /logs/agent/system_monitor.log every 60s (parity with condor's
 #      src/utils/system_monitor.sh)
 #
@@ -15,6 +16,8 @@
 # alignment with actual agent start time.
 
 set -e
+
+/usr/local/bin/initialize-nvidia-gpu-stack
 
 mkdir -p /logs/agent /logs/verifier
 

--- a/src/harbor_adapter/template/tests/Dockerfile
+++ b/src/harbor_adapter/template/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.9.1-cudnn-devel-ubuntu22.04
+FROM primeintellect/nvidia-driver-images:590.48.01-cuda12.9-devel-ubuntu22.04-k6.16.9
 
 # Verifier image for harbor's separate-verifier mode (PR #1655). Built
 # from `tests/` as context — Harbor builds this image whenever the
@@ -8,6 +8,9 @@ FROM nvidia/cuda:12.9.1-cudnn-devel-ubuntu22.04
 # Mirrors environment/Dockerfile (the agent image) so any Python the
 # verifier imports — vllm, transformers, inspect_evals — resolves
 # identically across both containers. Differences vs. agent Dockerfile:
+#   - Prime VM sandboxes need a driver-aware guest image. Prime's CUDA
+#     base mirrors upstream CUDA while adding NVIDIA driver hotplug,
+#     Fabric Manager, and /dev/nvidia* initialization for VM GPUs.
 #   - No `COPY . /home/agent/workspace/`: agent's workspace contents
 #     arrive at runtime via the artifact transfer, NOT baked in.
 #   - `COPY . /tests/` instead: test.sh, evaluate.py, templates/,
@@ -91,5 +94,17 @@ RUN rm -f /tests/Dockerfile \
           /tests/system_monitor.sh \
           /tests/requirements-direct.txt && \
     chmod +x /tests/test.sh
+
+ENV PRIME_EXPECTED_GPU_COUNT=1
+ENV PRIME_EXPECTED_NVSWITCH_COUNT=0
+RUN sed -i \
+        -e 's/PRIME_EXPECTED_GPU_COUNT:-8/PRIME_EXPECTED_GPU_COUNT:-1/g' \
+        -e 's/PRIME_EXPECTED_NVSWITCH_COUNT:-4/PRIME_EXPECTED_NVSWITCH_COUNT:-0/g' \
+        /usr/local/bin/wait-for-nvidia-hotplug-topology \
+        /usr/local/bin/initialize-nvidia-gpu-stack && \
+    sed -i '/\/usr\/local\/bin\/start-nvidia-fabricmanager/i if [[ "${expected_switch_count}" == "0" ]]; then exit 0; fi' \
+        /usr/local/bin/initialize-nvidia-gpu-stack && \
+    sed -i '/# Wait for Fabric Manager to finish registering every GPU for NVSwitch fabrics\./i if [[ "${expected_switch_count}" == "0" ]]; then exit 0; fi' \
+        /usr/local/bin/initialize-nvidia-gpu-stack
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
This stacks on top of #8 and makes the generated Harbor agent/verifier images capable of seeing GPUs in Prime VM sandboxes.

Changes:
- switch Harbor agent/verifier images from upstream `nvidia/cuda` to Prime's driver-aware CUDA VM base
- set the expected Prime GPU/NVSwitch topology for 1-GPU, no-NVSwitch PTB sandboxes
- invoke `initialize-nvidia-gpu-stack` from the PTB entrypoint before log streaming and monitoring starts
- skip the Fabric Manager branch for zero-NVSwitch sandboxes

Validation run on 2026-06-01:
- `git diff --check -- src/harbor_adapter/template/environment/Dockerfile src/harbor_adapter/template/tests/Dockerfile src/harbor_adapter/template/environment/entrypoint.sh`
- `bash -n src/harbor_adapter/template/environment/entrypoint.sh`
- built Prime image `cmmvfch400000n3w57owbyhkq/posttrainbench-gsm8k-qwen3-1.7b-agent:pr8-c9176a7-primecuda1gpu-init-skipfm` as both container and VM artifacts

GPU VM smoke is currently blocked by Prime VM sandbox startup: tiny control images on `H200_141GB` and `RTX_PRO_6000` terminate before reaching runnable state with `exit_code=1`, and `prime sandbox logs` returns HTTP 500 for those VM sandboxes. Prime CLI was upgraded from 0.6.6 to the available 0.6.9 path and the H200 control still failed the same way.