### PR TITLE
Fix agent self-kill and cross-job kill, enable reasoning in claude's traces 

### DIFF
--- a/agents/claude/solve.sh
+++ b/agents/claude/solve.sh
@@ -5,4 +5,5 @@ unset CODEX_API_KEY
 export BASH_MAX_TIMEOUT_MS="36000000"
 
 printf '%s' "$PROMPT" | claude --print --verbose --model "$AGENT_CONFIG" \
-    --output-format stream-json --dangerously-skip-permissions
+    --output-format stream-json --thinking-display summarized \
+    --dangerously-skip-permissions

--- a/agents/claude/solve.sh
+++ b/agents/claude/solve.sh
@@ -4,5 +4,5 @@ unset CODEX_API_KEY
 
 export BASH_MAX_TIMEOUT_MS="36000000"
 
-claude --print --verbose --model "$AGENT_CONFIG" --output-format stream-json \
-    --dangerously-skip-permissions "$PROMPT"
+printf '%s' "$PROMPT" | claude --print --verbose --model "$AGENT_CONFIG" \
+    --output-format stream-json --dangerously-skip-permissions

--- a/agents/claude_non_api/solve.sh
+++ b/agents/claude_non_api/solve.sh
@@ -18,5 +18,5 @@ export BASH_MAX_TIMEOUT_MS="36000000"
 # Set default effort level to high for consistency  
 
 printf '%s' "$PROMPT" | claude --print --verbose --model "$AGENT_CONFIG" \
-    --output-format stream-json --effort high \
+    --output-format stream-json --effort high --thinking-display summarized \
     --dangerously-skip-permissions

--- a/agents/claude_non_api/solve.sh
+++ b/agents/claude_non_api/solve.sh
@@ -17,6 +17,6 @@ export BASH_MAX_TIMEOUT_MS="36000000"
 
 # Set default effort level to high for consistency  
 
-claude --print --verbose --model "$AGENT_CONFIG" --output-format stream-json \
-    --effort high \
-    --dangerously-skip-permissions "$PROMPT"
+printf '%s' "$PROMPT" | claude --print --verbose --model "$AGENT_CONFIG" \
+    --output-format stream-json --effort high \
+    --dangerously-skip-permissions

--- a/agents/claude_non_api_max/solve.sh
+++ b/agents/claude_non_api_max/solve.sh
@@ -18,5 +18,5 @@ export BASH_MAX_TIMEOUT_MS="36000000"
 # Set effort level to max (Opus 4.6 only — absolute maximum reasoning, no token constraints)
 export CLAUDE_CODE_EFFORT_LEVEL="max"
 
-claude --print --verbose --model "$AGENT_CONFIG" --output-format stream-json \
-    --dangerously-skip-permissions "$PROMPT"
+printf '%s' "$PROMPT" | claude --print --verbose --model "$AGENT_CONFIG" \
+    --output-format stream-json --dangerously-skip-permissions

--- a/agents/claude_non_api_max/solve.sh
+++ b/agents/claude_non_api_max/solve.sh
@@ -19,4 +19,5 @@ export BASH_MAX_TIMEOUT_MS="36000000"
 export CLAUDE_CODE_EFFORT_LEVEL="max"
 
 printf '%s' "$PROMPT" | claude --print --verbose --model "$AGENT_CONFIG" \
-    --output-format stream-json --dangerously-skip-permissions
+    --output-format stream-json --thinking-display summarized \
+    --dangerously-skip-permissions

--- a/agents/claude_reprompt/solve.sh
+++ b/agents/claude_reprompt/solve.sh
@@ -7,7 +7,8 @@ export BASH_MAX_TIMEOUT_MS="36000000"
 MIN_REMAINING_MINUTES=30
 
 printf '%s' "$PROMPT" | claude --print --verbose --model "$AGENT_CONFIG" \
-    --output-format stream-json --dangerously-skip-permissions
+    --output-format stream-json --thinking-display summarized \
+    --dangerously-skip-permissions
 
 # Re-prompt loop: if the agent finishes early, resume the session
 while true; do
@@ -27,5 +28,6 @@ while true; do
     CONTINUATION_PROMPT="You still have ${REMAINING_HOURS}h ${REMAINING_MINS}m remaining. Please continue improving your result and maximize performance."
 
     printf '%s' "$CONTINUATION_PROMPT" | claude --print --verbose --continue --model "$AGENT_CONFIG" \
-        --output-format stream-json --dangerously-skip-permissions
+        --output-format stream-json --thinking-display summarized \
+        --dangerously-skip-permissions
 done

--- a/agents/claude_reprompt/solve.sh
+++ b/agents/claude_reprompt/solve.sh
@@ -6,8 +6,8 @@ export BASH_MAX_TIMEOUT_MS="36000000"
 
 MIN_REMAINING_MINUTES=30
 
-claude --print --verbose --model "$AGENT_CONFIG" --output-format stream-json \
-    --dangerously-skip-permissions "$PROMPT"
+printf '%s' "$PROMPT" | claude --print --verbose --model "$AGENT_CONFIG" \
+    --output-format stream-json --dangerously-skip-permissions
 
 # Re-prompt loop: if the agent finishes early, resume the session
 while true; do
@@ -26,6 +26,6 @@ while true; do
 
     CONTINUATION_PROMPT="You still have ${REMAINING_HOURS}h ${REMAINING_MINS}m remaining. Please continue improving your result and maximize performance."
 
-    claude --print --verbose --continue --model "$AGENT_CONFIG" --output-format stream-json \
-        --dangerously-skip-permissions "$CONTINUATION_PROMPT"
+    printf '%s' "$CONTINUATION_PROMPT" | claude --print --verbose --continue --model "$AGENT_CONFIG" \
+        --output-format stream-json --dangerously-skip-permissions
 done

--- a/agents/codex/solve.sh
+++ b/agents/codex/solve.sh
@@ -7,4 +7,4 @@ echo $OPENAI_API_KEY
 echo codex
 echo $CODEX_API_KEY
 
-codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG"

--- a/agents/codex_non_api/solve.sh
+++ b/agents/codex_non_api/solve.sh
@@ -11,4 +11,4 @@ if ! grep -q "forced_login_method" ~/.codex/config.toml 2>/dev/null; then
     printf '\nforced_login_method = "chatgpt"\n' >> ~/.codex/config.toml
 fi
 
-codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG"

--- a/agents/codex_non_api_high/solve.sh
+++ b/agents/codex_non_api_high/solve.sh
@@ -18,4 +18,4 @@ printf 'model_reasoning_effort = "high"\n\n' > "$tmp"
 [ -f "$file" ] && cat "$file" >> "$tmp"
 mv "$tmp" "$file"
 
-codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG"

--- a/agents/codex_non_api_high_reprompt/solve.sh
+++ b/agents/codex_non_api_high_reprompt/solve.sh
@@ -20,7 +20,7 @@ mv "$tmp" "$file"
 
 MIN_REMAINING_MINUTES=30
 
-codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG"
 
 # Re-prompt loop: if the agent finishes early, resume the session
 while true; do
@@ -39,5 +39,5 @@ while true; do
 
     CONTINUATION_PROMPT="You still have ${REMAINING_HOURS}h ${REMAINING_MINS}m remaining. Please continue improving your result and maximize performance."
 
-    codex --search exec resume --last --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$CONTINUATION_PROMPT"
+    printf '%s' "$CONTINUATION_PROMPT" | codex --search exec resume --last --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" -
 done

--- a/agents/codex_non_api_reprompt/solve.sh
+++ b/agents/codex_non_api_reprompt/solve.sh
@@ -13,7 +13,7 @@ fi
 
 MIN_REMAINING_MINUTES=30
 
-codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG"
 
 # Re-prompt loop: if the agent finishes early, resume the session
 while true; do
@@ -32,5 +32,5 @@ while true; do
 
     CONTINUATION_PROMPT="You still have ${REMAINING_HOURS}h ${REMAINING_MINS}m remaining. Please continue improving your result and maximize performance."
 
-    codex --search exec resume --last --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$CONTINUATION_PROMPT"
+    printf '%s' "$CONTINUATION_PROMPT" | codex --search exec resume --last --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" -
 done

--- a/agents/codex_non_api_xhigh/solve.sh
+++ b/agents/codex_non_api_xhigh/solve.sh
@@ -18,4 +18,4 @@ printf 'model_reasoning_effort = "xhigh"\n\n' > "$tmp"
 [ -f "$file" ] && cat "$file" >> "$tmp"
 mv "$tmp" "$file"
 
-codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG"

--- a/agents/codex_non_api_xhigh_reprompt/solve.sh
+++ b/agents/codex_non_api_xhigh_reprompt/solve.sh
@@ -20,7 +20,7 @@ mv "$tmp" "$file"
 
 MIN_REMAINING_MINUTES=30
 
-codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG"
 
 # Re-prompt loop: if the agent finishes early, resume the session
 while true; do
@@ -39,5 +39,5 @@ while true; do
 
     CONTINUATION_PROMPT="You still have ${REMAINING_HOURS}h ${REMAINING_MINS}m remaining. Please continue improving your result and maximize performance."
 
-    codex --search exec resume --last --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$CONTINUATION_PROMPT"
+    printf '%s' "$CONTINUATION_PROMPT" | codex --search exec resume --last --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" -
 done

--- a/agents/codex_xhigh/solve.sh
+++ b/agents/codex_xhigh/solve.sh
@@ -9,4 +9,4 @@ printf 'model_reasoning_effort = "xhigh"\n\n' > "$tmp"
 [ -f "$file" ] && cat "$file" >> "$tmp"
 mv "$tmp" "$file"
 
-codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG"

--- a/agents/codex_xhigh_reprompt/solve.sh
+++ b/agents/codex_xhigh_reprompt/solve.sh
@@ -11,7 +11,7 @@ mv "$tmp" "$file"
 
 MIN_REMAINING_MINUTES=30
 
-codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG"
 
 # Re-prompt loop: if the agent finishes early, resume the session
 while true; do
@@ -30,5 +30,5 @@ while true; do
 
     CONTINUATION_PROMPT="You still have ${REMAINING_HOURS}h ${REMAINING_MINS}m remaining. Please continue improving your result and maximize performance."
 
-    codex --search exec resume --last --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$CONTINUATION_PROMPT"
+    printf '%s' "$CONTINUATION_PROMPT" | codex --search exec resume --last --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "$AGENT_CONFIG" -
 done

--- a/agents/codexhigh/solve.sh
+++ b/agents/codexhigh/solve.sh
@@ -9,4 +9,4 @@ printf 'model_reasoning_effort = "high"\n\n' > "$tmp"
 [ -f "$file" ] && cat "$file" >> "$tmp"
 mv "$tmp" "$file"
 
-codex --search exec --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --skip-git-repo-check --yolo --model "$AGENT_CONFIG"

--- a/agents/codexlow/solve.sh
+++ b/agents/codexlow/solve.sh
@@ -9,4 +9,4 @@ printf 'model_reasoning_effort = "low"\n\n' > "$tmp"
 [ -f "$file" ] && cat "$file" >> "$tmp"
 mv "$tmp" "$file"
 
-codex --search exec --skip-git-repo-check --yolo --model "$AGENT_CONFIG" "$PROMPT"
+printf '%s' "$PROMPT" | codex --search exec --skip-git-repo-check --yolo --model "$AGENT_CONFIG"

--- a/agents/glm5/solve.sh
+++ b/agents/glm5/solve.sh
@@ -14,5 +14,5 @@ export ANTHROPIC_BASE_URL="https://api.z.ai/api/anthropic"
 export ANTHROPIC_MODEL="${AGENT_CONFIG}"
 export ANTHROPIC_SMALL_FAST_MODEL="${AGENT_CONFIG}"
 
-claude --print --verbose --model "$AGENT_CONFIG" --output-format stream-json \
-    --dangerously-skip-permissions "$PROMPT"
+printf '%s' "$PROMPT" | claude --print --verbose --model "$AGENT_CONFIG" \
+    --output-format stream-json --dangerously-skip-permissions

--- a/agents/opencode/solve.sh
+++ b/agents/opencode/solve.sh
@@ -42,4 +42,4 @@ cat > opencode.json << 'EOF'
 }
 EOF
 
-opencode run --model "$AGENT_CONFIG" --format json "$PROMPT"
+printf '%s' "$PROMPT" | opencode run --model "$AGENT_CONFIG" --format json

--- a/agents/qwen3max/solve.sh
+++ b/agents/qwen3max/solve.sh
@@ -19,5 +19,5 @@ echo "DEBUG: ANTHROPIC_API_KEY is set: ${ANTHROPIC_API_KEY:+yes} (length: ${#ANT
 echo "DEBUG: ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL}"
 echo "DEBUG: ANTHROPIC_MODEL=${ANTHROPIC_MODEL}"
 
-claude --print --verbose --model "$AGENT_CONFIG" --output-format stream-json \
-    --dangerously-skip-permissions "$PROMPT"
+printf '%s' "$PROMPT" | claude --print --verbose --model "$AGENT_CONFIG" \
+    --output-format stream-json --dangerously-skip-permissions

--- a/containers/opus_4_8.def
+++ b/containers/opus_4_8.def
@@ -1,0 +1,79 @@
+Bootstrap: docker
+From: nvidia/cuda:12.9.1-cudnn-devel-ubuntu22.04
+
+%files
+    containers/requirements-direct.txt /opt/requirements-direct.txt
+
+%post
+    chmod 1777 /tmp
+    # Set environment variables
+    export DEBIAN_FRONTEND=noninteractive
+
+    # Update and install system dependencies
+    apt-get update && apt-get install -y \
+        python3.10 \
+        python3-dev \
+        git \
+        wget \
+        curl \
+        build-essential \
+        && rm -rf /var/lib/apt/lists/*
+
+    # Create python3 symlink
+    ln -sf /usr/bin/python3.10 /usr/bin/python3
+    ln -sf /usr/bin/python3.10 /usr/bin/python
+    
+    # Install Node.js (LTS version 22.x) for npm
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+    apt-get install -y nodejs
+    
+    # Install uv
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="/root/.local/bin:$PATH"
+    
+    uv pip install --system --no-cache vllm==0.11.0 --torch-backend=auto
+
+    #  Pinned direct dependencies
+    uv pip install --system --no-cache -r /opt/requirements-direct.txt
+
+    #  flash-attn (needs no-build-isolation)
+    uv pip install --system --no-cache flash-attn==2.8.3 --no-build-isolation
+
+    #  AI CLI tools
+    npm install -g \
+        @anthropic-ai/claude-code@2.1.157 \
+        @openai/codex@0.135.0 \
+        @google/gemini-cli@0.18.4 \
+        opencode-ai@1.1.59
+
+    
+
+    # install inspect evals
+    mkdir -p /opt
+    cd /opt
+    git clone https://github.com/UKGovernmentBEIS/inspect_evals.git
+    cd /opt/inspect_evals
+    git checkout 06001a83e6d7c709c2ede0570dce7f1031a0bad8
+    uv pip install --system --no-cache .
+
+    # install inspect ai with debug 
+    mkdir -p /opt
+    cd /opt
+    git clone https://github.com/rank-and-file/inspect_ai_vllm_stdout.git
+    cd inspect_ai_vllm_stdout
+    uv pip install --system --no-cache .
+    
+%environment
+    export PATH="/root/.local/bin:$PATH"
+    export NO_PROXY="localhost,127.0.0.1"
+    export no_proxy="localhost,127.0.0.1"
+
+%runscript
+    exec python3 "$@"
+
+%labels
+    Version v1.0
+    Description Python ML container with CUDA support for transformers and LLM training (using uv) + AI CLI tools
+
+%help
+    Note: Use the --nv flag to enable NVIDIA GPU support when running the container.

--- a/src/run_task.sh
+++ b/src/run_task.sh
@@ -124,6 +124,7 @@ solve_task() {
         --nv \
         -c \
         --pid \
+        --no-init \
         --env PATH="/root/.local/bin:/home/ben/.local/bin:$PATH" \
         --env HF_HOME="${HF_HOME_NEW}" \
         --env ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \

--- a/src/run_task.sh
+++ b/src/run_task.sh
@@ -123,6 +123,7 @@ solve_task() {
     apptainer exec \
         --nv \
         -c \
+        --pid \
         --env PATH="/root/.local/bin:/home/ben/.local/bin:$PATH" \
         --env HF_HOME="${HF_HOME_NEW}" \
         --env ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \


### PR DESCRIPTION
Runs were silently terminating with SIGTERM (exit 143),  most visibly in the recent opus-4-8  batch: 

Two compounding bugs:

1. **Prompt in argv.** Every `agents/*/solve.sh` passed `"$PROMPT"` as a positional argument to the CLI. The full prompt text,  which contains the literal token `evaluate.py` four times  ended up in the agent process's `argv`. When the model later ran a cleanup like `pkill -f evaluate.py`, that substring matched the agent's own command line. The agent killed itself.

2. **No PID namespace.** `src/run_task.sh` invoked `apptainer exec` with `-c` (`--contain`), which isolates `/tmp` and `$HOME` but **not** the PID namespace. `pkill` inside one container therefore saw every other apptainer container's processes on the same host, and one job's cleanup could nuke neighbouring jobs.



### Changes

**`src/run_task.sh`** - added `--pid` to the agent-phase `apptainer exec`. The container now gets a private PID namespace, so `pkill`/`kill` inside it cannot reach processes in other containers

**`agents/*/solve.sh`** - switched from positional `"$PROMPT"` to `printf '%s' "$PROMPT" | <cli>` so the prompt text is delivered via stdin and no longer appears in `ps` / `pkill -f` output. (done for Claude code, Codex CLI, and OpenCode) 

(not done for Gemini CLI as we won't be using it in the future most likely) 