### PR TITLE
Add Modal support: run the full benchmark on cloud GPUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,7 @@ __marimo__/
 
 # testing parsed agent traces 
 output.txt
+
+# Modal adapter run ledger
+modal_runs.jsonl
+results_modal/

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ bash src/commit_utils/commit.sh
 
 Currently, we only support the HTCondor job scheduler. [Harbor](https://github.com/harbor-framework/harbor) support is planned.
 
+#### Running on Modal (cloud GPUs, no cluster required)
+
+The full pipeline (agent → contamination judge → evaluation) can also run on
+[Modal](https://modal.com) rented H100s — see
+[`src/modal_adapter/README.md`](src/modal_adapter/README.md) for setup,
+costs (~$55–60 per standard 10h run), and the differences from the cluster
+setup.
+
 #### API-based agents
 
 Most agents authenticate via API keys set as environment variables (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`). These are passed into the container automatically by `run_task.sh`. Set them in your environment before running `commit.sh`.

--- a/src/modal_adapter/README.md
+++ b/src/modal_adapter/README.md
@@ -1,0 +1,137 @@
+# Running PostTrainBench on Modal
+
+This adapter runs the full benchmark pipeline on [Modal](https://modal.com)
+(serverless cloud GPUs) instead of an HTCondor cluster. It is purely
+additive: the cluster path (`src/run_task.sh`, `src/commit_utils/`) is
+untouched, and each pipeline phase here is a direct port of the
+corresponding section of `run_task.sh`.
+
+Each run (agent x model x task) is a chain of three Modal Functions:
+
+```
+submit.py (your laptop; exits immediately)
+  └─ run_agent   standard image,   1..8x H100   the agent post-trains for num_hours
+       └─ run_judge   standard image,  CPU only    codex contamination judge, fresh container
+            └─ run_eval    vllm_debug image, 1x H100   evaluate.py max-tokens retry ladder
+```
+
+All phases write into the `ptb-results` volume using the exact `EVAL_DIR`
+layout of the cluster, so downloaded results feed `scripts/collect.py` and
+friends unchanged.
+
+## One-time setup
+
+1. Install and authenticate the Modal CLI:
+
+   ```bash
+   pip install modal        # or: uv tool install modal
+   modal setup
+   ```
+
+2. Create the secret with your API keys (unused ones can be empty; the last
+   two are only for subscription-based agents and replace the `auth.json` /
+   `oauth_token` files that `run_task.sh` copies from `agents/<agent>/`):
+
+   ```bash
+   modal secret create posttrainbench-keys \
+       OPENAI_API_KEY=... ANTHROPIC_API_KEY=... GEMINI_API_KEY=... \
+       OPENCODE_API_KEY="" DASHSCOPE_API_KEY="" ZAI_API_KEY="" \
+       CODEX_AUTH_JSON="" CLAUDE_OAUTH_TOKEN=""
+   ```
+
+3. Deploy the app (builds both container images on first run; expect a
+   while for the vLLM/flash-attn layers):
+
+   ```bash
+   modal deploy src/modal_adapter/app.py
+   ```
+
+4. Sanity-check without benchmark spend:
+
+   ```bash
+   modal run src/modal_adapter/app.py::smoke_check       # CPU: images, CLIs, volumes, secret
+   modal run src/modal_adapter/app.py::gpu_smoke_check   # ~1 min on an H100 (~$0.10)
+   ```
+
+5. Seed the HuggingFace cache volume. The download runs *inside* Modal
+   (nothing is uploaded from your machine). For a first end-to-end test,
+   seed the minimal subset; the full cache covers all of
+   `containers/download_hf_cache/resources.json` and takes hours:
+
+   ```bash
+   modal run src/modal_adapter/app.py::seed_smoke            # 1 model + 1 dataset, minutes
+   modal run --detach src/modal_adapter/app.py::seed_full    # everything (run detached)
+   ```
+
+## Submitting runs
+
+```bash
+# Cheap end-to-end test (~$10-15): 1 hour of claude on gsm8k
+python src/modal_adapter/submit.py \
+    --agent claude --agent-config claude-opus-4-5 \
+    --eval gsm8k --model Qwen/Qwen3-1.7B-Base --num-hours 1
+
+# A real cell (~$55-60): 10 hours, then judge + eval
+python src/modal_adapter/submit.py \
+    --agent claude --agent-config claude-opus-4-5 \
+    --eval healthbench --model Qwen/Qwen3-4B-Base --num-hours 10
+
+# Sweeps: --eval and --model are repeatable
+python src/modal_adapter/submit.py \
+    --agent codex --agent-config gpt-5.3-codex \
+    --eval gsm8k --eval humaneval --eval gpqamain \
+    --model Qwen/Qwen3-4B-Base --model HuggingFaceTB/SmolLM3-3B-Base \
+    --num-hours 10
+```
+
+Spawned runs keep going after your laptop disconnects. Each submission is
+recorded in `modal_runs.jsonl` at the repo root.
+
+## Monitoring and collecting results
+
+```bash
+python src/modal_adapter/status.py       # per-run phase progress
+modal app logs posttrainbench            # live logs (also on the web dashboard)
+
+modal volume get ptb-results / ./results_modal
+python scripts/collect.py --data-dir ./results_modal   # existing tooling, unchanged
+```
+
+## Costs (Modal list prices, mid-2026)
+
+| Item | Cost |
+|---|---|
+| H100 | ~$3.95/h (billed per second) |
+| Standard run (10h agent + judge + eval) | ~$55–60 |
+| Full sweep, 7 tasks x 4 models, one agent config | ~$1.6k |
+| 1h smoke run | ~$10–15 |
+| Storage (cache + results volumes) | per byte-day; small next to compute |
+
+Concurrency: Modal's Starter plan allows 10 concurrent GPUs (excess runs
+queue automatically); the Team plan allows 50.
+
+## Differences from the cluster setup
+
+1. **HF cache overlay**: fuse-overlayfs cannot mount inside Modal's gVisor
+   runtime, so the read-only cache volume is exposed through a symlink farm
+   on container SSD (`hf_cache_lib.sh`). Same throwaway-write semantics; the
+   one edge case is that overwriting an already-cached file in place fails
+   instead of copying up.
+2. **Judge runs CPU-only.** It is code inspection via the codex CLI; on the
+   cluster it merely happened to run on a GPU node.
+3. **Eval always uses 1x H100**, regardless of the agent phase's
+   `--num-gpus` (final models are <=4B).
+4. **Preemption**: Modal GPU containers can be preempted (rare, but
+   possible on long runs, and it cannot be disabled). A preempted phase
+   restarts from scratch automatically (up to 2 retries for the agent
+   phase); every attempt is recorded in the run's `attempts.log`, and a
+   finished eval is never re-run (`metrics.json` short-circuit).
+5. **Isolation**: the agent runs as a subprocess inside the same container
+   as the phase harness (on the cluster, the harness runs on the host
+   outside apptainer). The judge and eval still run in fresh containers, so
+   nothing the agent does to its environment can leak into them.
+6. **Run IDs** are submission epoch-seconds instead of condor cluster IDs
+   (still integers, still ordered, as `scripts/utils.py` expects).
+7. **`--num-hours` is capped at 22** (Modal Functions max out at 24h). The
+   8-GPU / 50-100h experiments from `commit.sh` are out of scope here;
+   `--num-gpus` up to 8 works for runs within the cap.

--- a/src/modal_adapter/app.py
+++ b/src/modal_adapter/app.py
@@ -1,0 +1,641 @@
+"""Modal adapter: run the full PostTrainBench pipeline on modal.com.
+
+Each benchmark run (agent x model x task) is a chain of three Modal Functions,
+mirroring the phases of src/run_task.sh:
+
+    run_agent  (standard image,   H100)  -> spawns
+    run_judge  (standard image,   CPU)   -> spawns
+    run_eval   (vllm_debug image, H100)
+
+All phases write into the `ptb-results` Volume using the exact EVAL_DIR layout
+that scripts/collect.py expects, so results pulled with `modal volume get`
+feed the existing analysis scripts unchanged.
+
+Usage: see src/modal_adapter/README.md. Deploy with
+    modal deploy src/modal_adapter/app.py
+then submit runs with src/modal_adapter/submit.py.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import modal
+
+APP_NAME = "posttrainbench"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ADAPTER = "/repo/src/modal_adapter"
+
+RESULTS_MOUNT = "/results"
+HF_RO_MOUNT = "/hf_cache_ro"
+HF_RW_MOUNT = "/hf_cache"
+JOB_DIR = "/home/ben"
+
+# 24h Modal cap minus slack for setup + artifact copy.
+MAX_NUM_HOURS = 22
+
+app = modal.App(APP_NAME)
+
+# Volume v2: the HF cache holds far more files than v1's comfortable limits.
+hf_cache = modal.Volume.from_name("ptb-hf-cache", create_if_missing=True, version=2)
+results = modal.Volume.from_name("ptb-results", create_if_missing=True, version=2)
+
+# One secret holds everything. API keys mirror single_task.sub's environment
+# line; CODEX_AUTH_JSON / CLAUDE_OAUTH_TOKEN are optional and replace the
+# auth.json / oauth_token files that run_task.sh copies from agents/<agent>/.
+keys_secret = modal.Secret.from_name("posttrainbench-keys")
+
+CUDA_BASE = "nvidia/cuda:12.9.1-cudnn-devel-ubuntu22.04"
+
+NODESOURCE = "curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -y nodejs"
+UV_INSTALL = "curl -LsSf https://astral.sh/uv/install.sh | sh"
+
+# Puts uv on the default PATH for any subprocess (the .def files do this via
+# a PATH prepend in %environment, which Image.env() can't express).
+UV_SYMLINK = (
+    "ln -sf /root/.local/bin/uv /usr/local/bin/uv"
+    " && ln -sf /root/.local/bin/uvx /usr/local/bin/uvx"
+)
+
+# Package list from containers/standard.def
+STANDARD_PACKAGES = [
+    "accelerate",
+    "boto3",
+    "bitsandbytes",
+    "datasets",
+    "evaluate",
+    "lm-eval",
+    "openai",
+    "pandas",
+    "scikit-learn",
+    "shortuuid",
+    "tokenizers",
+    "transformers",
+    "trl",
+    "peft",
+    "tiktoken",
+    "inspect-ai",
+    "matplotlib",
+    "certifi",
+]
+
+# Note: the .def files also prepend /root/.local/bin (uv) to PATH; here the
+# phase scripts do that at runtime instead, because Image.env() shell-quotes
+# values, so "$PATH" would not expand.
+COMMON_ENV = {
+    "PYTHONNOUSERSITE": "1",
+    "NO_PROXY": "localhost,127.0.0.1",
+    "no_proxy": "localhost,127.0.0.1",
+}
+
+
+def _with_repo(image: modal.Image) -> modal.Image:
+    """Mount the repo files the pipeline needs at /repo (runtime mount)."""
+    return (
+        image.add_local_dir(
+            REPO_ROOT / "src",
+            "/repo/src",
+            ignore=["**/__pycache__", "**/*.pyc"],
+        )
+        .add_local_dir(
+            REPO_ROOT / "agents",
+            "/repo/agents",
+            # Never bake subscription credentials into the image; they are
+            # provided via the posttrainbench-keys secret instead.
+            ignore=["**/auth.json", "**/oauth_token", "**/__pycache__"],
+        )
+        .add_local_dir(
+            REPO_ROOT / "containers",
+            "/repo/containers",
+            ignore=["**/*.sif", "**/__pycache__"],
+        )
+    )
+
+
+# Port of containers/standard.def
+standard_image = (
+    modal.Image.from_registry(CUDA_BASE, add_python="3.10")
+    .entrypoint([])
+    .apt_install("git", "wget", "curl", "build-essential", "tree", "rsync")
+    .run_commands(
+        NODESOURCE,
+        "npm install -g"
+        " @anthropic-ai/claude-code@2.0.55"
+        " @openai/codex@0.79.0"
+        " @google/gemini-cli@0.18.4"
+        " opencode-ai@1.1.59",
+        UV_INSTALL,
+    )
+    # The .def files pass --torch-backend=auto, which needs a CUDA driver at
+    # build time to pick an index; Modal builders are CPU-only, so resolve
+    # from PyPI instead (torch wheels bundle their own CUDA runtime).
+    .uv_pip_install("vllm==0.11.0")
+    # wheel/setuptools/psutil are required for --no-build-isolation installs;
+    # the .def files get them implicitly from the Ubuntu python environment.
+    .uv_pip_install("ninja", "packaging", "wheel", "setuptools", "psutil")
+    .uv_pip_install(*STANDARD_PACKAGES)
+    .uv_pip_install("flash_attn", extra_options="--no-build-isolation")
+    # standard.def installs inspect_evals from HEAD, but current HEAD requires
+    # Python >=3.11; pin the same commit vllm_debug.def pins (3.10-compatible).
+    .run_commands(
+        "git clone https://github.com/UKGovernmentBEIS/inspect_evals.git /opt/inspect_evals"
+        " && cd /opt/inspect_evals"
+        " && git checkout 06001a83e6d7c709c2ede0570dce7f1031a0bad8"
+        " && python -m pip install --no-cache-dir ."
+    )
+    .run_commands(UV_SYMLINK)
+    .env(COMMON_ENV)
+)
+
+# Port of containers/vllm_debug.def
+vllm_debug_image = (
+    modal.Image.from_registry(CUDA_BASE, add_python="3.10")
+    .entrypoint([])
+    .apt_install("git", "wget", "curl", "build-essential", "rsync")
+    .run_commands(
+        NODESOURCE,
+        "npm install -g"
+        " @anthropic-ai/claude-code@2.1.34"
+        " @openai/codex@0.98.0"
+        " @google/gemini-cli@0.18.4"
+        " opencode-ai@1.1.59",
+        UV_INSTALL,
+    )
+    # The .def files pass --torch-backend=auto, which needs a CUDA driver at
+    # build time to pick an index; Modal builders are CPU-only, so resolve
+    # from PyPI instead (torch wheels bundle their own CUDA runtime).
+    .uv_pip_install("vllm==0.11.0")
+    .uv_pip_install(requirements=[str(REPO_ROOT / "containers" / "requirements-direct.txt")])
+    # wheel/setuptools/psutil are required for --no-build-isolation installs;
+    # the .def files get them implicitly from the Ubuntu python environment.
+    .uv_pip_install("wheel", "setuptools", "psutil")
+    .uv_pip_install("flash-attn==2.8.3", extra_options="--no-build-isolation")
+    .run_commands(
+        "git clone https://github.com/UKGovernmentBEIS/inspect_evals.git /opt/inspect_evals"
+        " && cd /opt/inspect_evals"
+        " && git checkout 06001a83e6d7c709c2ede0570dce7f1031a0bad8"
+        " && python -m pip install --no-cache-dir .",
+        # The patched inspect_ai fork must be installed last so it overrides
+        # the inspect-ai pulled in by earlier dependencies.
+        "git clone https://github.com/rank-and-file/inspect_ai_vllm_stdout.git /opt/inspect_ai_vllm_stdout"
+        " && python -m pip install --no-cache-dir /opt/inspect_ai_vllm_stdout",
+    )
+    .run_commands(UV_SYMLINK)
+    .env(COMMON_ENV)
+)
+
+standard_runtime = _with_repo(standard_image)
+vllm_debug_runtime = _with_repo(vllm_debug_image)
+
+
+# ---------------------------------------------------------------------------
+# Run spec helpers
+# ---------------------------------------------------------------------------
+
+# Same character set as run_task.sh: tr '/:[]' '____'
+_SAFE_TR = str.maketrans({c: "_" for c in "/:[]"})
+
+
+def build_spec(
+    eval_task: str,
+    agent: str,
+    agent_config: str,
+    model_to_train: str,
+    run_id: int,
+    num_hours: int = 10,
+    num_gpus: int = 1,
+    experiment_name: str = "",
+    prompt_variant: str = "prompt",
+) -> dict:
+    return {
+        "eval_task": eval_task,
+        "agent": agent,
+        "agent_config": agent_config,
+        "model_to_train": model_to_train,
+        "run_id": int(run_id),
+        "num_hours": int(num_hours),
+        "num_gpus": int(num_gpus),
+        "experiment_name": experiment_name,
+        "prompt_variant": prompt_variant,
+    }
+
+
+def eval_dir_rel(spec: dict) -> str:
+    """EVAL_DIR relative to the results root; must match run_task.sh:13-24."""
+    agent_config_safe = spec["agent_config"].translate(_SAFE_TR)
+    model_safe = spec["model_to_train"].translate(_SAFE_TR)
+    gpu_suffix = f"_{spec['num_gpus']}gpu" if spec["num_gpus"] > 1 else ""
+    method = (
+        f"{spec['agent']}_{agent_config_safe}_{spec['num_hours']}h"
+        f"{gpu_suffix}{spec['experiment_name']}"
+    )
+    return f"{method}/{spec['eval_task']}_{model_safe}_{spec['run_id']}"
+
+
+def _phase_env(spec: dict, local_eval_dir: str) -> dict:
+    env = dict(os.environ)
+    env.update(
+        {
+            "EVALUATION_TASK": spec["eval_task"],
+            "AGENT": spec["agent"],
+            "AGENT_CONFIG": spec["agent_config"],
+            "MODEL_TO_TRAIN": spec["model_to_train"],
+            "NUM_HOURS": str(spec["num_hours"]),
+            "NUM_GPUS": str(spec["num_gpus"]),
+            "RUN_ID": str(spec["run_id"]),
+            "POST_TRAIN_BENCH_PROMPT": spec.get("prompt_variant", "prompt"),
+            "LOCAL_EVAL_DIR": local_eval_dir,
+            "REPO": "/repo",
+            "JOB_DIR": JOB_DIR,
+            "HF_RO": HF_RO_MOUNT,
+        }
+    )
+    return env
+
+
+def _publish(local_eval_dir: str, spec: dict) -> None:
+    """Copy the staged EVAL_DIR contents onto the results volume and commit."""
+    dest = Path(RESULTS_MOUNT) / eval_dir_rel(spec)
+    dest.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(
+        local_eval_dir,
+        dest,
+        dirs_exist_ok=True,
+        symlinks=True,
+        ignore_dangling_symlinks=True,
+    )
+    results.commit()
+
+
+def _fetch(rel_path: str, local_path: str) -> bool:
+    """Copy a file/dir from the results volume to local disk. True if found."""
+    src = Path(RESULTS_MOUNT) / rel_path
+    if not src.exists():
+        return False
+    if src.is_dir():
+        shutil.copytree(src, local_path, dirs_exist_ok=True, symlinks=True)
+    else:
+        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, local_path)
+    return True
+
+
+def _log_attempt(spec: dict, phase: str) -> None:
+    """Record each container attempt: preemptions/retries restart phases from
+    scratch, and this makes that visible in the run's results directory."""
+    dest = Path(RESULTS_MOUNT) / eval_dir_rel(spec)
+    dest.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).isoformat()
+    task_id = os.environ.get("MODAL_TASK_ID", "unknown")
+    with open(dest / "attempts.log", "a") as f:
+        f.write(f"{stamp} phase={phase} modal_task={task_id}\n")
+    results.commit()
+
+
+def _spawn_next(function_name: str, spec: dict) -> None:
+    modal.Function.from_name(APP_NAME, function_name).spawn(spec)
+
+
+# ---------------------------------------------------------------------------
+# Phase functions
+# ---------------------------------------------------------------------------
+
+
+@app.function(
+    image=standard_runtime,
+    gpu="H100",
+    cpu=8,
+    memory=65536,
+    # Ceiling only; submit.py tightens this per run via .with_options().
+    # The inner `timeout` in phase_agent.sh is what actually enforces num_hours.
+    timeout=84600,
+    retries=modal.Retries(initial_delay=0.0, max_retries=2),
+    single_use_containers=True,
+    volumes={
+        HF_RO_MOUNT: hf_cache.with_mount_options(read_only=True),
+        RESULTS_MOUNT: results,
+    },
+    secrets=[keys_secret],
+)
+def run_agent(spec: dict) -> str:
+    """Phase 1: let the CLI agent post-train the model (run_task.sh:13-188)."""
+    rel = eval_dir_rel(spec)
+    _log_attempt(spec, "agent")
+
+    local_eval_dir = "/tmp/eval_dir_out"
+    Path(local_eval_dir).mkdir(parents=True, exist_ok=True)
+
+    proc = subprocess.run(
+        ["bash", f"{ADAPTER}/phase_agent.sh"],
+        env=_phase_env(spec, local_eval_dir),
+    )
+    # Mirror run_task.sh: agent failure is not fatal; judge + eval still run.
+    # Raising here would also trigger Modal retries, re-billing the GPU hours.
+    Path(local_eval_dir, "agent_phase_exit_code.txt").write_text(f"{proc.returncode}\n")
+
+    _publish(local_eval_dir, spec)
+    _spawn_next("run_judge", spec)
+    return rel
+
+
+@app.function(
+    image=standard_runtime,
+    cpu=8,
+    memory=16384,
+    timeout=7200,
+    volumes={
+        HF_RO_MOUNT: hf_cache.with_mount_options(read_only=True),
+        RESULTS_MOUNT: results,
+    },
+    secrets=[keys_secret],
+)
+def run_judge(spec: dict) -> str:
+    """Phase 2: contamination judge (run_task.sh:190-219).
+
+    Runs in a fresh container so nothing the agent did to its own container
+    can leak into the judge -- the same guarantee apptainer's per-exec
+    writable tmpfs gives on the cluster. The judge is code inspection (codex
+    CLI over the task directory), so it gets no GPU.
+    """
+    rel = eval_dir_rel(spec)
+    _log_attempt(spec, "judge")
+
+    local_eval_dir = "/tmp/eval_dir_out"
+    Path(local_eval_dir).mkdir(parents=True, exist_ok=True)
+
+    # Reconstruct the job dir the way the cluster's judge sees it.
+    Path(JOB_DIR).mkdir(parents=True, exist_ok=True)
+    if not _fetch(f"{rel}/task", f"{JOB_DIR}/task"):
+        print(f"WARNING: no task directory found under {rel}; judge has nothing to inspect")
+        Path(JOB_DIR, "task").mkdir(parents=True, exist_ok=True)
+    _fetch(f"{rel}/solve_parsed.txt", f"{JOB_DIR}/solve_parsed.txt")
+
+    proc = subprocess.run(
+        ["bash", f"{ADAPTER}/phase_judge.sh"],
+        env=_phase_env(spec, local_eval_dir),
+    )
+    Path(local_eval_dir, "judge_phase_exit_code.txt").write_text(f"{proc.returncode}\n")
+
+    _publish(local_eval_dir, spec)
+    _spawn_next("run_eval", spec)
+    return rel
+
+
+@app.function(
+    image=vllm_debug_runtime,
+    gpu="H100",
+    cpu=8,
+    memory=65536,
+    timeout=82800,
+    volumes={
+        HF_RO_MOUNT: hf_cache.with_mount_options(read_only=True),
+        RESULTS_MOUNT: results,
+    },
+    secrets=[keys_secret],
+)
+def run_eval(spec: dict) -> str:
+    """Phase 3: evaluate final_model (run_task.sh:243-363)."""
+    rel = eval_dir_rel(spec)
+
+    # Idempotency across Modal-level retries/preemptions: the ladder in
+    # run_task.sh short-circuits on an existing metrics.json; do the same here.
+    if (Path(RESULTS_MOUNT) / rel / "metrics.json").exists():
+        print(f"metrics.json already present for {rel}; skipping evaluation")
+        return rel
+
+    _log_attempt(spec, "eval")
+
+    local_eval_dir = "/tmp/eval_dir_out"
+    Path(local_eval_dir).mkdir(parents=True, exist_ok=True)
+
+    if not _fetch(f"{rel}/final_model", "/work/final_model"):
+        # Mirror the cluster: the ladder still runs (and fails fast per
+        # attempt), so the run leaves the same artifacts either way.
+        print(f"WARNING: no final_model found under {rel}")
+
+    proc = subprocess.run(
+        ["bash", f"{ADAPTER}/phase_eval.sh"],
+        env=_phase_env(spec, local_eval_dir),
+    )
+    Path(local_eval_dir, "eval_phase_exit_code.txt").write_text(f"{proc.returncode}\n")
+
+    _publish(local_eval_dir, spec)
+    return rel
+
+
+# ---------------------------------------------------------------------------
+# HF cache seeding
+# ---------------------------------------------------------------------------
+
+
+@app.function(
+    image=standard_runtime,
+    cpu=8,
+    memory=65536,
+    timeout=86400,
+    volumes={HF_RW_MOUNT: hf_cache},
+    secrets=[keys_secret],
+)
+def seed_hf_cache(models_filter: list = None, datasets_filter: list = None) -> str:
+    """Populate the ptb-hf-cache volume by running the repo's own download
+    script inside Modal (no laptop upload). Optional filters select a subset
+    of resources.json for cheap smoke seeding."""
+    src_dir = Path("/repo/containers/download_hf_cache")
+    work = Path("/tmp/seed")
+    work.mkdir(parents=True, exist_ok=True)
+    # download_resources.py resolves resources.json next to itself, so run a
+    # copy with a (possibly filtered) resources.json beside it.
+    shutil.copy2(src_dir / "download_resources.py", work / "download_resources.py")
+    resources = json.loads((src_dir / "resources.json").read_text())
+    if models_filter is not None:
+        resources["models"] = [m for m in resources["models"] if m in set(models_filter)]
+    if datasets_filter is not None:
+        wanted = set(datasets_filter)
+        resources["datasets"] = [d for d in resources["datasets"] if d["dataset"] in wanted]
+    (work / "resources.json").write_text(json.dumps(resources, indent=2))
+
+    env = dict(os.environ)
+    env["HF_HOME"] = HF_RW_MOUNT
+    subprocess.run(
+        ["python", str(work / "download_resources.py")], env=env, check=True
+    )
+    hf_cache.commit()
+    du = subprocess.run(
+        ["du", "-sh", HF_RW_MOUNT], capture_output=True, text=True
+    ).stdout.strip()
+    print(f"Seeding complete. Cache size: {du}")
+    return du
+
+
+@app.local_entrypoint()
+def seed_smoke():
+    """Minimal cache for a cheap end-to-end test: one model + one dataset."""
+    print(seed_hf_cache.remote(["Qwen/Qwen3-1.7B-Base"], ["openai/gsm8k"]))
+
+
+@app.local_entrypoint()
+def seed_full():
+    """Full cache (hours; run with `modal run --detach`)."""
+    print(seed_hf_cache.remote(None, None))
+
+
+# ---------------------------------------------------------------------------
+# Smoke checks (no benchmark spend)
+# ---------------------------------------------------------------------------
+
+
+def _smoke_report(image_name: str) -> dict:
+    report = {"image": image_name}
+
+    for mod in ("torch", "vllm", "inspect_ai", "transformers", "datasets", "trl"):
+        try:
+            m = __import__(mod)
+            # str(): e.g. torch.__version__ is a TorchVersion, which would
+            # fail to unpickle on a laptop without torch installed.
+            report[f"import:{mod}"] = str(getattr(m, "__version__", "ok"))
+        except Exception as e:  # noqa: BLE001
+            report[f"import:{mod}"] = f"FAIL: {e}"
+
+    for cli in ("claude", "codex", "gemini", "opencode", "uv"):
+        try:
+            out = subprocess.run(
+                [cli, "--version"], capture_output=True, text=True, timeout=120
+            )
+            report[f"cli:{cli}"] = (out.stdout or out.stderr).strip().splitlines()[0]
+        except Exception as e:  # noqa: BLE001
+            report[f"cli:{cli}"] = f"FAIL: {e}"
+
+    needed = [
+        "/repo/src/run_task.sh",
+        "/repo/src/eval/general/get_prompt.py",
+        "/repo/src/eval/tasks/gsm8k/evaluate.py",
+        "/repo/src/disallowed_usage_judge/get_judge_prompt.py",
+        "/repo/src/utils/create_timer.sh",
+        "/repo/agents/claude/solve.sh",
+        "/repo/containers/other_home_data/.codex",
+        "/repo/containers/delete_hf_models.py",
+        "/repo/containers/download_hf_cache/resources.json",
+    ]
+    report["repo_files"] = {p: os.path.exists(p) for p in needed}
+
+    prompt = subprocess.run(
+        [
+            "python", "src/eval/general/get_prompt.py",
+            "--model-to-train", "Qwen/Qwen3-1.7B-Base",
+            "--benchmark-id", "gsm8k",
+            "--num-hours", "1",
+            "--num-gpus", "1",
+            "--agent", "claude",
+        ],
+        capture_output=True, text=True, cwd="/repo",
+    )
+    report["get_prompt"] = "ok" if prompt.returncode == 0 and "GSM8K" in prompt.stdout else f"FAIL: {prompt.stderr[-500:]}"
+
+    for key in (
+        "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
+        "OPENCODE_API_KEY", "DASHSCOPE_API_KEY", "ZAI_API_KEY",
+    ):
+        report[f"secret:{key}"] = "set" if os.environ.get(key) else "EMPTY"
+
+    try:
+        report["hf_cache_ro_entries"] = len(os.listdir(HF_RO_MOUNT))
+    except Exception as e:  # noqa: BLE001
+        report["hf_cache_ro_entries"] = f"FAIL: {e}"
+
+    # Results volume write/read round-trip.
+    try:
+        probe = Path(RESULTS_MOUNT) / "_smoke" / f"probe_{int(time.time())}.txt"
+        probe.parent.mkdir(parents=True, exist_ok=True)
+        probe.write_text("ok")
+        results.commit()
+        report["results_volume"] = probe.read_text()
+        probe.unlink()
+        results.commit()
+    except Exception as e:  # noqa: BLE001
+        report["results_volume"] = f"FAIL: {e}"
+
+    # Symlink-farm mechanics on a toy tree (the fuse-overlayfs replacement).
+    try:
+        lower = Path("/tmp/farm_lower/hub/models--org--m")
+        lower.mkdir(parents=True)
+        (lower / "weights.bin").write_text("lower-content")
+        upper = Path("/tmp/farm_upper")
+        subprocess.run(
+            ["bash", "-c", f". {ADAPTER}/hf_cache_lib.sh && hf_symlink_farm /tmp/farm_lower {upper}"],
+            check=True,
+        )
+        assert (upper / "hub/models--org--m/weights.bin").read_text() == "lower-content"
+        (upper / "hub/models--org--m/new_file.txt").write_text("upper-write")
+        report["symlink_farm"] = "ok"
+    except Exception as e:  # noqa: BLE001
+        report["symlink_farm"] = f"FAIL: {e}"
+
+    return report
+
+
+@app.function(
+    image=standard_runtime,
+    cpu=4,
+    memory=16384,
+    timeout=1800,
+    volumes={
+        HF_RO_MOUNT: hf_cache.with_mount_options(read_only=True),
+        RESULTS_MOUNT: results,
+    },
+    secrets=[keys_secret],
+)
+def smoke_standard() -> dict:
+    return _smoke_report("standard")
+
+
+@app.function(
+    image=vllm_debug_runtime,
+    cpu=4,
+    memory=16384,
+    timeout=1800,
+    volumes={
+        HF_RO_MOUNT: hf_cache.with_mount_options(read_only=True),
+        RESULTS_MOUNT: results,
+    },
+    secrets=[keys_secret],
+)
+def smoke_vllm_debug() -> dict:
+    return _smoke_report("vllm_debug")
+
+
+@app.function(image=standard_runtime, gpu="H100", cpu=4, memory=16384, timeout=900)
+def gpu_smoke() -> dict:
+    report = {}
+    for script in ("check_cuda.py", "check_cuda_writing.py"):
+        proc = subprocess.run(
+            ["python", f"/repo/src/utils/{script}"], capture_output=True, text=True
+        )
+        report[script] = "ok" if proc.returncode == 0 else f"FAIL: {proc.stdout[-300:]} {proc.stderr[-300:]}"
+    smi = subprocess.run(
+        ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader"],
+        capture_output=True, text=True,
+    )
+    report["nvidia-smi"] = smi.stdout.strip() or smi.stderr.strip()
+    return report
+
+
+@app.local_entrypoint()
+def smoke_check():
+    """CPU-only checks of both images, volumes, secrets, and repo mounts."""
+    for fn in (smoke_standard, smoke_vllm_debug):
+        report = fn.remote()
+        print(f"\n===== {report.pop('image')} image =====")
+        for k, v in report.items():
+            print(f"  {k}: {v}")
+
+
+@app.local_entrypoint()
+def gpu_smoke_check():
+    """One short H100 container (~a minute) running the repo's CUDA checks."""
+    for k, v in gpu_smoke.remote().items():
+        print(f"  {k}: {v}")

--- a/src/modal_adapter/hf_cache_lib.sh
+++ b/src/modal_adapter/hf_cache_lib.sh
@@ -1,0 +1,29 @@
+# Shared helpers for the Modal adapter phase scripts.
+#
+# hf_symlink_farm replaces run_task.sh's with_huggingface_overlay:
+# fuse-overlayfs cannot mount inside Modal's gVisor runtime, so instead of an
+# overlay mount we build a "symlink farm". Every directory of the read-only
+# HF cache volume is recreated as a real (writable) directory on container
+# disk, and every file becomes a symlink into the read-only volume. Existing
+# cache content is read through the symlinks; new downloads land on container
+# disk and are discarded with the container -- the same throwaway-upper-layer
+# semantics as the overlay. The one difference: overwriting an already-cached
+# file in place fails (read-only) instead of copying up.
+
+hf_symlink_farm() {
+    local lower="$1"
+    local target="$2"
+    mkdir -p "$target"
+    if [ -d "$lower" ] && [ -n "$(ls -A "$lower" 2>/dev/null)" ]; then
+        cp -rs "$lower/." "$target/"
+    fi
+}
+
+# Print `-u VAR` arguments for env(1) that strip Modal-internal variables from
+# the environment handed to agent/judge subprocesses. On the cluster the
+# containers inherit the host environment; the Modal equivalent should not
+# leak MODAL_* runtime variables (e.g. the identity token) to the agent.
+modal_env_unsets() {
+    compgen -e | grep '^MODAL_' | sed 's/^/-u /' | tr '\n' ' '
+    true
+}

--- a/src/modal_adapter/phase_agent.sh
+++ b/src/modal_adapter/phase_agent.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Modal port of src/run_task.sh phases 1-2: job setup, agent solve, trace
+# parse, cleanup (run_task.sh lines 13-188 and 221-239). Differences:
+#   - no apptainer: the Modal container IS the job container, so the solve
+#     pipeline runs directly with an adjusted environment;
+#   - fuse-overlayfs HF cache replaced by hf_symlink_farm (see hf_cache_lib.sh);
+#   - artifacts are staged into LOCAL_EVAL_DIR; app.py copies them to the
+#     results volume afterwards.
+#
+# Inputs via environment (set by app.py:run_agent):
+#   EVALUATION_TASK AGENT AGENT_CONFIG MODEL_TO_TRAIN NUM_HOURS NUM_GPUS
+#   LOCAL_EVAL_DIR REPO JOB_DIR HF_RO POST_TRAIN_BENCH_PROMPT
+#   plus the API keys from the posttrainbench-keys secret.
+
+source "${REPO}/src/modal_adapter/hf_cache_lib.sh"
+
+mkdir -p "${LOCAL_EVAL_DIR}"
+exec 1> >(tee "${LOCAL_EVAL_DIR}/output.log")
+exec 2> >(tee "${LOCAL_EVAL_DIR}/error.log" >&2)
+
+echo "agent phase: task=${EVALUATION_TASK} agent=${AGENT} config=${AGENT_CONFIG} model=${MODEL_TO_TRAIN} hours=${NUM_HOURS} gpus=${NUM_GPUS}"
+
+cd "${REPO}"
+
+export HF_HOME_NEW="${JOB_DIR}/hf_cache"
+export PYTHONNOUSERSITE=1
+
+echo "Preparing job directory..."
+mkdir -p "${JOB_DIR}"
+mkdir -p "${JOB_DIR}/task"
+
+cp "src/eval/tasks/${EVALUATION_TASK}/evaluate.py" "${JOB_DIR}/task"
+if [ -d "src/eval/tasks/${EVALUATION_TASK}/evaluation_code" ]; then
+    cp -r "src/eval/tasks/${EVALUATION_TASK}/evaluation_code" "${JOB_DIR}/task"
+fi
+cp -r src/eval/templates "${JOB_DIR}/task/"
+
+if [ -d "src/eval/tasks/${EVALUATION_TASK}/task_context" ]; then
+    cp -r src/eval/tasks/${EVALUATION_TASK}/task_context/* "${JOB_DIR}/task"
+fi
+cp -r "containers/other_home_data/.codex" "${JOB_DIR}/"
+
+BENCHMARK=$(cat src/eval/tasks/${EVALUATION_TASK}/benchmark.txt)
+PROMPT=$(python src/eval/general/get_prompt.py --model-to-train "$MODEL_TO_TRAIN" --benchmark-id "$EVALUATION_TASK" --num-hours "$NUM_HOURS" --num-gpus "$NUM_GPUS" --agent "${AGENT}")
+echo "$PROMPT" > "${LOCAL_EVAL_DIR}/prompt.txt"
+
+bash src/utils/create_timer.sh $NUM_HOURS $JOB_DIR/task/timer.sh
+
+# set openai api keys appropriately (run_task.sh:64-69)
+export CODEX_API_KEY="${OPENAI_API_KEY:-}"
+unset OPENAI_API_KEY
+if [ "$EVALUATION_TASK" == "arenahardwriting" ] || [ "$EVALUATION_TASK" == "healthbench" ]; then
+    export OPENAI_API_KEY="${CODEX_API_KEY}"
+fi
+
+# Copy scripts needed inside the job dir
+cp src/utils/check_cuda.py "${JOB_DIR}/check_cuda.py"
+cp src/utils/check_cuda_writing.py "${JOB_DIR}/check_cuda_writing.py"
+cp src/utils/system_monitor.sh "${JOB_DIR}/system_monitor.sh"
+cp src/utils/timestamp_lines.py "${JOB_DIR}/timestamp_lines.py"
+cp "agents/${AGENT}/solve.sh" "${JOB_DIR}/agent_solve.sh"
+
+# Agent-specific auth for non-API agents. run_task.sh copies these from
+# agents/<agent>/; on Modal they come from the posttrainbench-keys secret.
+if [ -n "${CODEX_AUTH_JSON:-}" ]; then
+    printf '%s' "${CODEX_AUTH_JSON}" > "${JOB_DIR}/.codex/auth.json"
+fi
+if [ -n "${CLAUDE_OAUTH_TOKEN:-}" ]; then
+    printf '%s' "${CLAUDE_OAUTH_TOKEN}" > "${JOB_DIR}/oauth_token"
+fi
+
+with_record_the_time() {
+    local begin=$(date --iso-8601=seconds)
+    "$@"
+    local exit_code=$?
+    local end=$(date --iso-8601=seconds)
+
+    local time_taken=$(( $(date --date="$end" +%s) - $(date --date="$begin" +%s) ))
+    printf '%02d:%02d:%02d\n' \
+        $(( time_taken / 3600 )) \
+        $(( (time_taken % 3600) / 60 )) \
+        $(( time_taken % 60 )) > "${LOCAL_EVAL_DIR}/time_taken.txt"
+
+    return $exit_code
+}
+
+SOLVE_OUT="${LOCAL_EVAL_DIR}/solve_out.txt"
+
+# The cluster passes the host environment plus overrides into the container
+# (apptainer -c contains the filesystem, not the environment). Mirror that:
+# inherit everything except MODAL_* internals, with the same overrides that
+# run_task.sh sets via --env (run_task.sh:122-147).
+solve_task() {
+    timeout --signal=TERM --kill-after=30s "$((NUM_HOURS * 60 + 5))m" \
+    env $(modal_env_unsets) \
+        HOME="${JOB_DIR}" \
+        PATH="/root/.local/bin:${JOB_DIR}/.local/bin:${PATH}" \
+        HF_HOME="${HF_HOME_NEW}" \
+        VLLM_API_KEY="inspectai" \
+        PYTHONNOUSERSITE="1" \
+        NUM_GPUS="${NUM_GPUS}" \
+        PROMPT="${PROMPT}" \
+        AGENT_CONFIG="${AGENT_CONFIG}" \
+        bash -c "cd '${JOB_DIR}/task' && { python '${JOB_DIR}/check_cuda.py' && python '${JOB_DIR}/check_cuda_writing.py' || exit 1; bash '${JOB_DIR}/system_monitor.sh' & MONITOR_PID=\$!; bash '${JOB_DIR}/agent_solve.sh'; kill \$MONITOR_PID 2>/dev/null; } 2>&1 | python '${JOB_DIR}/timestamp_lines.py'" > "${SOLVE_OUT}" 2>&1
+}
+
+echo "================================"
+echo "========= RUNNING TASK ========="
+echo "================================"
+
+hf_symlink_farm "${HF_RO}" "${HF_HOME_NEW}"
+
+with_record_the_time solve_task
+SOLVE_EXIT=$?
+
+echo "--- SOLVE DIAGNOSTICS ---"
+echo "exit_code: $SOLVE_EXIT"
+if [ $SOLVE_EXIT -eq 0 ]; then
+    echo "status: exited normally"
+elif [ $SOLVE_EXIT -eq 124 ]; then
+    echo "status: killed by timeout (reached ${NUM_HOURS}h limit)"
+elif [ $SOLVE_EXIT -gt 128 ]; then
+    echo "status: killed by signal $((SOLVE_EXIT - 128)) ($(kill -l $((SOLVE_EXIT - 128)) 2>/dev/null || echo unknown))"
+else
+    echo "status: exited with error code $SOLVE_EXIT"
+fi
+echo "final_model_files: $(ls "${JOB_DIR}/task/final_model/" 2>/dev/null | wc -l)"
+echo "hostname: $(hostname)"
+echo "modal_task: ${MODAL_TASK_ID:-unknown}"
+echo "disk_job_dir: $(du -sh "${JOB_DIR}" 2>/dev/null | cut -f1)"
+echo "disk_tmp: $(du -sh /tmp 2>/dev/null | cut -f1)"
+echo "memory: $(free -m 2>/dev/null | grep Mem | awk '{print "total=" $2 "MB used=" $3 "MB free=" $4 "MB"}')"
+echo "--- END SOLVE DIAGNOSTICS ---"
+
+echo "============================================"
+echo "=== TASK COMPLETE, PARSING AGENT TRACE ==="
+echo "============================================"
+
+TRACE_PARSER="agents/${AGENT}/human_readable_trace.py"
+if [ -f "$TRACE_PARSER" ]; then
+    python "$TRACE_PARSER" "${SOLVE_OUT}" -o "${LOCAL_EVAL_DIR}/solve_parsed.txt"
+else
+    echo "Warning: No trace parser found at $TRACE_PARSER, using raw output"
+    cp "${SOLVE_OUT}" "${LOCAL_EVAL_DIR}/solve_parsed.txt"
+fi
+
+echo "============================="
+echo "======== CLEANING UP ========"
+echo "============================="
+
+echo "Task directory contents:"
+tree "${JOB_DIR}/task"
+echo "================================"
+
+if [ -d "${JOB_DIR}/task/final_model" ]; then
+    cp -r "${JOB_DIR}/task/final_model" "${LOCAL_EVAL_DIR}/final_model"
+fi
+
+if [ -f "${JOB_DIR}/task/system_monitor.log" ]; then
+    cp "${JOB_DIR}/task/system_monitor.log" "${LOCAL_EVAL_DIR}/system_monitor.log"
+fi
+
+python containers/delete_hf_models.py "${JOB_DIR}/task"
+
+cp -r "${JOB_DIR}/task" "${LOCAL_EVAL_DIR}/task"
+
+echo "agent phase done"
+exit $SOLVE_EXIT

--- a/src/modal_adapter/phase_eval.sh
+++ b/src/modal_adapter/phase_eval.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Modal port of src/run_task.sh's evaluation phase (lines 243-363): the
+# max-tokens retry ladder over the per-task evaluate.py. Differences:
+#   - runs in its own fresh container (vllm_debug image), so the
+#     `nvidia-smi ... kill -9` GPU-process cleanup between attempts is gone;
+#   - the repo's src tree is copied to a writable /work (the /repo mount is
+#     read-only and inspect_ai writes logs/ into the task cwd);
+#   - final_model is at /work/final_model (copied from the results volume by
+#     app.py:run_eval).
+#
+# Inputs via environment (set by app.py:run_eval):
+#   EVALUATION_TASK LOCAL_EVAL_DIR REPO HF_RO plus API keys from the secret.
+
+source "${REPO}/src/modal_adapter/hf_cache_lib.sh"
+
+mkdir -p "${LOCAL_EVAL_DIR}"
+
+echo "================================"
+echo "========= EVALUATING ==========="
+echo "================================"
+
+# set openai api keys appropriately (run_task.sh:64-69): the eval container
+# only receives OPENAI_API_KEY for the model-graded tasks.
+CODEX_API_KEY="${OPENAI_API_KEY:-}"
+unset OPENAI_API_KEY
+if [ "$EVALUATION_TASK" == "arenahardwriting" ] || [ "$EVALUATION_TASK" == "healthbench" ]; then
+    export OPENAI_API_KEY="${CODEX_API_KEY}"
+fi
+
+mkdir -p /work
+cp -r "${REPO}/src" /work/src
+
+export TMP_HF_CACHE="/tmp/hf_cache_90afd0"
+hf_symlink_farm "${HF_RO}" "${TMP_HF_CACHE}"
+
+export EVAL_COUNTER=0
+export LOCAL_EVAL_DIR
+export EVALUATION_TASK
+
+run_evaluation() {
+    local max_tokens_arg="$1"
+    local eval_num="$2"
+    sleep 5
+    (
+        cd "/work/src/eval/tasks/${EVALUATION_TASK}" && \
+        env $(modal_env_unsets) \
+            HF_HOME="${TMP_HF_CACHE}" \
+            OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
+            VLLM_API_KEY="inspectai" \
+            PYTHONNOUSERSITE="1" \
+            python evaluate.py \
+                --model-path /work/final_model \
+                --templates-dir ../../../../src/eval/templates \
+                --limit -1 \
+                ${max_tokens_arg} \
+                --json-output-file "${LOCAL_EVAL_DIR}/metrics.json"
+    ) > "${LOCAL_EVAL_DIR}/final_eval_${eval_num}.txt" 2>&1
+}
+
+run_evaluation_with_retry() {
+    local max_retries="$1"
+    local max_tokens_arg="$2"
+
+    for ((attempt=1; attempt<=max_retries; attempt++)); do
+        sleep 5
+        if [ -f "${LOCAL_EVAL_DIR}/metrics.json" ]; then
+            return 0
+        fi
+
+        EVAL_COUNTER=$((EVAL_COUNTER + 1))
+        export EVAL_COUNTER
+        echo "Evaluation attempt $EVAL_COUNTER (phase attempt $attempt of $max_retries)"
+
+        timeout --signal=TERM --kill-after=60s 28800s bash -c "$(declare -f run_evaluation modal_env_unsets); run_evaluation \"$max_tokens_arg\" \"$EVAL_COUNTER\""
+
+        if [ -f "${LOCAL_EVAL_DIR}/metrics.json" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# First evaluation: up to 4 attempts
+run_evaluation_with_retry 4 ""
+
+# Second evaluation with adjusted max tokens: up to 3 attempts
+case "${EVALUATION_TASK}" in
+    aime2025)
+        MAX_TOKENS_ARG="--max-tokens 12000"
+        ;;
+    arenahardwriting)
+        MAX_TOKENS_ARG="--max-new-tokens 12288"
+        ;;
+    bfcl)
+        MAX_TOKENS_ARG="--max-tokens 12000"
+        ;;
+    gpqamain)
+        MAX_TOKENS_ARG="--max-tokens 12000"
+        ;;
+    gsm8k)
+        MAX_TOKENS_ARG="--max-tokens 3000"
+        ;;
+    healthbench)
+        MAX_TOKENS_ARG="--max-new-tokens 12288"
+        ;;
+    humaneval)
+        MAX_TOKENS_ARG="--max-tokens 3000"
+        ;;
+    *)
+        MAX_TOKENS_ARG=""
+        ;;
+esac
+
+run_evaluation_with_retry 3 "$MAX_TOKENS_ARG"
+
+# Third evaluation with further adjusted max tokens: up to 2 attempts
+case "${EVALUATION_TASK}" in
+    aime2025)
+        MAX_TOKENS_ARG="--max-tokens 8000"
+        ;;
+    arenahardwriting)
+        MAX_TOKENS_ARG="--max-new-tokens 8192"
+        ;;
+    bfcl)
+        MAX_TOKENS_ARG="--max-tokens 8000"
+        ;;
+    gpqamain)
+        MAX_TOKENS_ARG="--max-tokens 8000"
+        ;;
+    gsm8k)
+        MAX_TOKENS_ARG="--max-tokens 2000"
+        ;;
+    healthbench)
+        MAX_TOKENS_ARG="--max-new-tokens 8192"
+        ;;
+    humaneval)
+        MAX_TOKENS_ARG="--max-tokens 2000"
+        ;;
+    *)
+        MAX_TOKENS_ARG=""
+        ;;
+esac
+
+run_evaluation_with_retry 2 "$MAX_TOKENS_ARG"
+
+if [ "${EVAL_COUNTER}" -gt 0 ] && [ -f "${LOCAL_EVAL_DIR}/final_eval_${EVAL_COUNTER}.txt" ]; then
+    echo $(cat "${LOCAL_EVAL_DIR}/final_eval_${EVAL_COUNTER}.txt")
+fi
+
+echo "================================"
+echo "======= EVALUATION DONE ========"
+echo "================================"
+
+[ -f "${LOCAL_EVAL_DIR}/metrics.json" ]

--- a/src/modal_adapter/phase_judge.sh
+++ b/src/modal_adapter/phase_judge.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Modal port of src/run_task.sh's contamination-judge phase (lines 190-219).
+# Runs in a fresh container; app.py has already reconstructed the job dir
+# (task/ and solve_parsed.txt from the results volume).
+#
+# Inputs via environment (set by app.py:run_judge):
+#   EVALUATION_TASK MODEL_TO_TRAIN LOCAL_EVAL_DIR REPO JOB_DIR HF_RO
+#   POST_TRAIN_BENCH_PROMPT plus API keys from the secret.
+
+source "${REPO}/src/modal_adapter/hf_cache_lib.sh"
+
+mkdir -p "${LOCAL_EVAL_DIR}"
+cd "${REPO}"
+
+echo "========================================="
+echo "=== RUNNING CONTAMINATION JUDGE ==="
+echo "========================================="
+
+export HF_HOME_NEW="${JOB_DIR}/hf_cache"
+hf_symlink_farm "${HF_RO}" "${HF_HOME_NEW}"
+
+# The judge authenticates with the OpenAI key (run_task.sh:64-65).
+export CODEX_API_KEY="${OPENAI_API_KEY:-}"
+
+BENCHMARK=$(cat "src/eval/tasks/${EVALUATION_TASK}/benchmark.txt")
+JUDGE_TASK=$(python src/disallowed_usage_judge/get_judge_prompt.py --benchmark "${BENCHMARK}" --model "${MODEL_TO_TRAIN}")
+
+# Reset codex config to prevent agent-specific settings (e.g. model_reasoning_effort)
+# from leaking into the judge, which uses a different model
+cp -r "containers/other_home_data/.codex" "${JOB_DIR}/"
+
+cd "${JOB_DIR}/task"
+env $(modal_env_unsets) \
+    HOME="${JOB_DIR}" \
+    PATH="/root/.local/bin:${JOB_DIR}/.local/bin:${PATH}" \
+    HF_HOME="${HF_HOME_NEW}" \
+    CODEX_API_KEY="${CODEX_API_KEY}" \
+    VLLM_API_KEY="inspectai" \
+    PYTHONNOUSERSITE="1" \
+    codex --search -a never exec --json -c model_reasoning_summary=detailed --skip-git-repo-check --yolo --model "gpt-5.1-codex" "$JUDGE_TASK" 2>&1 | tee "${LOCAL_EVAL_DIR}/judge_output.json"
+
+cd "${REPO}"
+
+# Convert judge JSON output to human-readable format
+python agents/codex/human_readable_trace.py "${LOCAL_EVAL_DIR}/judge_output.json" -o "${LOCAL_EVAL_DIR}/judge_output.txt"
+
+cp "${JOB_DIR}/task/contamination_judgement.txt" "${LOCAL_EVAL_DIR}/contamination_judgement.txt" \
+    || echo "Warning: judge produced no contamination_judgement.txt"
+cp "${JOB_DIR}/task/disallowed_model_judgement.txt" "${LOCAL_EVAL_DIR}/disallowed_model_judgement.txt" \
+    || echo "Warning: judge produced no disallowed_model_judgement.txt"
+
+echo "judge phase done"

--- a/src/modal_adapter/status.py
+++ b/src/modal_adapter/status.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Show the status of submitted PostTrainBench runs on Modal.
+
+Reads modal_runs.jsonl (written by submit.py) and reports, per run:
+  - the state of the spawned run_agent call, and
+  - which pipeline phases have produced their artifacts on the results
+    volume (the volume is the source of truth; judge/eval are spawned
+    server-side, so their progress is visible through their outputs).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import modal
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from app import APP_NAME  # noqa: E402
+
+LEDGER = Path(__file__).resolve().parent.parent.parent / "modal_runs.jsonl"
+
+PHASE_MARKERS = [
+    ("agent", "time_taken.txt"),
+    ("judge", "contamination_judgement.txt"),
+    ("eval", "metrics.json"),
+]
+
+
+def agent_call_state(call_id: str) -> str:
+    try:
+        call = modal.FunctionCall.from_id(call_id)
+        call.get(timeout=0)
+        return "finished"
+    except TimeoutError:
+        return "queued/running"
+    except modal.exception.OutputExpiredError:
+        return "finished (output expired; see volume)"
+    except Exception as e:  # noqa: BLE001
+        return f"error: {type(e).__name__}: {e}"
+
+
+def main() -> None:
+    if not LEDGER.exists():
+        sys.exit(f"no ledger at {LEDGER}; submit runs with submit.py first")
+
+    results_vol = modal.Volume.from_name("ptb-results")
+    records = [json.loads(line) for line in LEDGER.read_text().splitlines() if line.strip()]
+
+    for rec in records:
+        rel = rec["eval_dir"]
+        try:
+            entries = {Path(e.path).name for e in results_vol.listdir(rel)}
+        except Exception:  # noqa: BLE001 - directory not created yet
+            entries = set()
+
+        phases = " ".join(
+            f"{name}:{'done' if marker in entries else '-'}"
+            for name, marker in PHASE_MARKERS
+        )
+        attempts = "attempts.log" in entries
+        print(
+            f"run {rec['run_id']}  {rel}\n"
+            f"    agent call: {agent_call_state(rec['call_id'])}   {phases}"
+            + ("   [has attempts.log]" if attempts else "")
+        )
+
+    print(
+        "\nFetch results:  modal volume get ptb-results / ./results_modal\n"
+        f"Live logs:      modal app logs {APP_NAME}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/modal_adapter/submit.py
+++ b/src/modal_adapter/submit.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Submit PostTrainBench runs to the deployed Modal app.
+
+Modal analogue of src/commit_utils/commit.sh: one spawned run_agent call per
+(model, eval task) cell. The calls run server-side on Modal, so this script
+(and your machine) can exit immediately after submitting.
+
+Example:
+    python src/modal_adapter/submit.py \
+        --agent claude --agent-config claude-opus-4-5 \
+        --eval gsm8k --model Qwen/Qwen3-1.7B-Base --num-hours 1
+
+Requires `modal deploy src/modal_adapter/app.py` first. Every submission is
+appended to modal_runs.jsonl at the repo root for status.py.
+"""
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import modal
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from app import (  # noqa: E402
+    APP_NAME,
+    HF_RO_MOUNT,
+    MAX_NUM_HOURS,
+    RESULTS_MOUNT,
+    build_spec,
+    eval_dir_rel,
+    hf_cache,
+    keys_secret,
+    results,
+)
+
+LEDGER = Path(__file__).resolve().parent.parent.parent / "modal_runs.jsonl"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--agent", required=True, help="agent dir under agents/, e.g. claude, codex, gemini, opencode")
+    parser.add_argument("--agent-config", required=True, help="model passed to the agent CLI, e.g. claude-opus-4-5")
+    parser.add_argument("--eval", dest="evals", action="append", required=True,
+                        help="task id under src/eval/tasks/ (repeatable)")
+    parser.add_argument("--model", dest="models", action="append", required=True,
+                        help="model to post-train, e.g. Qwen/Qwen3-4B-Base (repeatable)")
+    parser.add_argument("--num-hours", type=int, default=10)
+    parser.add_argument("--num-gpus", type=int, default=1)
+    parser.add_argument("--experiment-name", default="",
+                        help="suffix for the method dir, like POST_TRAIN_BENCH_EXPERIMENT_NAME")
+    parser.add_argument("--prompt-variant", default="prompt",
+                        help="prompt template name under src/eval/general/ (POST_TRAIN_BENCH_PROMPT)")
+    parser.add_argument("--dry-run", action="store_true", help="print what would be submitted and exit")
+    args = parser.parse_args()
+
+    if args.num_hours > MAX_NUM_HOURS:
+        sys.exit(
+            f"error: --num-hours {args.num_hours} exceeds the Modal adapter limit of {MAX_NUM_HOURS}h "
+            "(single Modal Function calls are capped at 24h)."
+        )
+
+    run_agent = modal.Function.from_name(APP_NAME, "run_agent")
+    if args.num_gpus > 1:
+        # with_options replaces volumes/secrets rather than extending them,
+        # so they must be re-specified alongside the resource overrides.
+        run_agent = run_agent.with_options(
+            gpu=f"H100:{args.num_gpus}",
+            cpu=min(8 * args.num_gpus, 64),
+            memory=min(65536 * args.num_gpus, 262144),
+            volumes={
+                HF_RO_MOUNT: hf_cache.with_mount_options(read_only=True),
+                RESULTS_MOUNT: results,
+            },
+            secrets=[keys_secret],
+        )
+
+    run_id_base = int(time.time())
+    submitted = []
+    i = 0
+    for model in args.models:
+        for eval_task in args.evals:
+            spec = build_spec(
+                eval_task=eval_task,
+                agent=args.agent,
+                agent_config=args.agent_config,
+                model_to_train=model,
+                run_id=run_id_base + i,
+                num_hours=args.num_hours,
+                num_gpus=args.num_gpus,
+                experiment_name=args.experiment_name,
+                prompt_variant=args.prompt_variant,
+            )
+            i += 1
+            if args.dry_run:
+                print(f"would submit: {eval_dir_rel(spec)}")
+                continue
+            call = run_agent.spawn(spec)
+            record = {
+                "run_id": spec["run_id"],
+                "call_id": call.object_id,
+                "eval_dir": eval_dir_rel(spec),
+                "spec": spec,
+                "submitted_at": datetime.now(timezone.utc).isoformat(),
+            }
+            with open(LEDGER, "a") as f:
+                f.write(json.dumps(record) + "\n")
+            submitted.append(record)
+            print(f"submitted {eval_dir_rel(spec)}  (call {call.object_id})")
+
+    if submitted:
+        print(f"\n{len(submitted)} run(s) submitted; ledger: {LEDGER}")
+        print("Watch progress: python src/modal_adapter/status.py  |  modal app logs posttrainbench")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Runs the full pipeline (agent → contamination judge → evaluation) on [Modal](https://modal.com) rented H100s, for anyone without cluster access. Purely additive — everything lives in `src/modal_adapter/` (same shape as the Harbor adapter in #8) and the condor path is untouched. Each phase script is a near line-for-line port of the corresponding section of `run_task.sh`, and results land in the exact `EVAL_DIR` layout, so `scripts/collect.py` works on downloaded results unchanged.

- One run = a chain of three Modal Functions: `run_agent` (standard image, 1–8×H100, ≤22h), `run_judge` (fresh CPU container, so agent tampering can't leak into the judge), `run_eval` (vllm_debug image, retry ladder as-is). Submissions are fire-and-forget from a laptop.
- Both `.def` files are translated to `modal.Image` chains; the HF cache is a Modal Volume seeded by running `download_resources.py` inside Modal, mounted read-only and exposed through a symlink farm (fuse-overlayfs can't mount in Modal's gVisor runtime — verified empirically).
- ~$55–60 per standard 10h run at list prices; full setup, usage, and a table of deviations from the cluster (preemption semantics, judge on CPU, run-id format, 22h cap) are in `src/modal_adapter/README.md`.

Verified so far: both images build and deploy; CPU smoke checks pass on both images (imports, pinned CLI versions, volumes, secret wiring, symlink farm); the repo's `check_cuda.py`/`check_cuda_writing.py` pass on a real H100. Not yet run: a paid end-to-end run — the README's smoke sequence (seed minimal cache, 1h claude run on gsm8k, ~$10–15) is the intended validation before this leaves draft.

Two notes for reviewers: `standard.def` installs inspect_evals from HEAD, which now requires Python ≥3.11 and would break a fresh cluster build too — the Modal image pins the same commit `vllm_debug.def` pins. And `--torch-backend=auto` needs a CUDA driver at build time, so the Modal images resolve vLLM from PyPI instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)