### PR TITLE
Hand off final_model to the verifier via a Harbor shared volume instead of the workspace tar

### DIFF
--- a/src/harbor_adapter/README.md
+++ b/src/harbor_adapter/README.md
@@ -28,8 +28,13 @@ Total: **28 tasks** (7 benchmarks x 4 models).
 ## Installation
 
 ```bash
-# Use the included pyproject.toml file to get the python environment with harbor and modal
+# Python environment for the adapter (modal etc.)
 uv sync
+
+# Harbor CLI. Task-declared shared volumes ([[environment.volumes]]) are not
+# yet in a Harbor release — install from the feature branch until the
+# upstream PR (harbor-framework/harbor) lands:
+uv tool install "harbor @ git+https://github.com/surelyMersad/harbor.git@feat/task-shared-volumes"
 ```
 
 ## Quick Start
@@ -98,6 +103,25 @@ posttrainbench-gsm8k-qwen3-1.7b/
 └── tests/
     └── test.sh            # Verifier: contamination judge + 3-phase eval retry
 ```
+
+## Model Hand-off via Shared Volume
+
+The verifier runs in a separate container (`[verifier].environment_mode =
+"separate"`), and the trained model reaches it via a **Harbor task-declared
+shared volume** (`[[environment.volumes]]`, name `model`):
+
+| Container | Mount path | Access |
+|-----------|-----------|--------|
+| Agent | `/home/agent/workspace/final_model` | read-write |
+| Verifier | `/mnt/model` | **read-only** |
+
+Harbor creates one volume per trial (`harbor-<trial>-model`), both containers
+attach the same volume, and Harbor deletes it at trial cleanup. On Modal the
+weights move as a [Modal Volume](https://modal.com/docs/guide/volumes),
+locally as a Docker named volume — never through the tar/host artifact path
+(which previously failed with exit code -1 on multi-GB workspaces).
+`final_model` is therefore excluded from the workspace artifact, which now
+carries only the contamination-judge inputs (the agent's source code).
 
 ## Evaluation Retry Logic
 

--- a/src/harbor_adapter/template/instruction.md
+++ b/src/harbor_adapter/template/instruction.md
@@ -6,6 +6,7 @@ You should perform automated research and development to post-train \`{model}\` 
 You can query the benchmark via the evaluate.py script.
 
 Store your best trained model in the folder \`final_model\`.
+Note: \`final_model\` already exists as a mounted volume. Write your model files into it (e.g. \`model.save_pretrained("final_model")\` or copying files in); do not delete or rename the folder itself.
 
 ## Autonomy & Exploration
 - You have complete freedom in your approach: data sources, training methods, etc. .

--- a/src/harbor_adapter/template/task.toml
+++ b/src/harbor_adapter/template/task.toml
@@ -29,6 +29,16 @@ start_period_sec = 5
 start_interval_sec = 1
 retries = 3
 
+# The agent's final_model directory is a harbor task-declared shared volume
+# ([[environment.volumes]]). The trained weights land directly on a
+# provider-managed persistent volume (Modal Volume on modal, named volume on
+# docker), and the separate verifier below attaches the SAME per-trial volume
+# read-only — the multi-GB weights never ride the tar/host artifact path that
+# previously died with exit code -1 on large workspaces.
+[[environment.volumes]]
+name = "model"
+path = "/home/agent/workspace/final_model"
+
 # Verifier runs in a SEPARATE container from the agent — harbor 0.7.0's
 # separate-verifier mode (PR #1655, docs:
 # https://www.harborframework.com/docs/tasks#verifier-environment-shared-vs-separate).
@@ -68,6 +78,14 @@ start_period_sec = 5
 start_interval_sec = 1
 retries = 3
 
+# Same logical volume as the agent's final_model (same `name` = same
+# underlying per-trial volume), mounted READ-ONLY so the verification phase
+# cannot modify the evidence it grades. test.sh evaluates /mnt/model.
+[[verifier.environment.volumes]]
+name = "model"
+path = "/mnt/model"
+read_only = true
+
 [agent]
 timeout_sec = 36000.0
 
@@ -75,22 +93,12 @@ timeout_sec = 36000.0
 # is transferred from the agent env to the verifier env at the same
 # path AND archived under <trial_dir>/artifacts/workspace/ on the host.
 #
-# One entry (was previously two — workspace + a separate final_model).
-# Rationale for collapsing:
-#   1. Two overlapping artifacts (final_model nested inside workspace)
-#      triggered harbor 0.15's UserWarning at task load and made
-#      upload order load-bearing (`upload_artifacts` calls
-#      `empty_dirs(target)` before each upload, so a later workspace
-#      upload would wipe an earlier final_model).
-#   2. Two tar ops on the agent env is two chances to hit harbor's
-#      flaky transfer path (empty stderr, code -1). One op is
-#      strictly better.
-#
-# `final_model` is NOT in the exclude list — we want the trained
-# weights carried in via this single artifact so the verifier has them
-# at /home/agent/workspace/final_model/. On the host they land at
-# artifacts/workspace/final_model/ (postmortem access, just one path
-# deeper than before).
+# This transfer now carries ONLY the contamination-judge inputs (the
+# agent's source code: .py, .md, .json configs, .sh). The trained
+# weights travel on the `model` shared volume declared above — they are
+# no longer part of this tar, which keeps the agent-side tar small and
+# avoids the flaky multi-GB transfer path (empty stderr, code -1) that
+# killed the 2026-05-27 and 2026-06-27 trials.
 #
 # The contamination judge in test.sh reads the agent's code via
 # `cd $WORKSPACE && codex exec ...` — the workspace transfer supplies
@@ -98,14 +106,11 @@ timeout_sec = 36000.0
 [[artifacts]]
 source = "/home/agent/workspace"
 destination = "workspace"
-# Aggressive excludes to keep the agent-side tar tractable. The
-# 2026-05-27 and 2026-06-27 trials died with harbor's tar exit code
-# -1 / empty stderr on multi-GB workspaces containing HF cache +
-# wandb + checkpoint dirs. Drop anything the contamination judge
-# doesn't need — judge only reads the agent's source code (.py, .md,
-# .json configs, .sh), not caches/checkpoints/logs. `final_model` is
-# deliberately kept so the verifier gets the weights.
 exclude = [
+    # The trained model arrives via the shared volume, not this tar.
+    # (final_model is a volume mountpoint in the agent container; tarring
+    # it would re-introduce the multi-GB transfer this PR removes.)
+    "final_model",
     # Standard hygiene:
     "__pycache__",
     "*.pyc",
@@ -118,13 +123,18 @@ exclude = [
     # Experiment tracking:
     "wandb",
     ".wandb",
-    # Training output dirs commonly produced by HF Trainer / Hydra
-    # (final_model is NOT excluded — we want it transferred):
+    # Training output dirs commonly produced by HF Trainer / Hydra:
     "checkpoint-*",
     "runs",
     "outputs",
     "output",
     "logs",
+    # Stray weight files outside final_model (large, not useful for judge):
+    "*.safetensors",
+    "*.pt",
+    "*.pth",
+    "*.ckpt",
+    "*.gguf",
     # Tokenized dataset shards (large, not useful for judge):
     "*.arrow",
     "*.parquet",

--- a/src/harbor_adapter/template/tests/test.sh
+++ b/src/harbor_adapter/template/tests/test.sh
@@ -17,16 +17,22 @@ set -e
 #     BAKED INTO the verifier image at build time (see tests/Dockerfile)
 #     and live at /tests/.
 #   - The agent's workspace at /home/agent/workspace is transferred from
-#     the agent container by harbor as a configured artifact and
-#     contains the agent's training scripts + final_model. The
-#     contamination judge reads these (cd $WORKSPACE && codex exec ...);
-#     evaluate.py reads /home/agent/workspace/final_model.
-#   - The agent's final_model is the only file the verifier executes
-#     code against (via vllm). Bad weights are penalized by the eval
-#     score, not by tampering.
+#     the agent container by harbor as a configured artifact (weight
+#     files excluded) and contains the agent's training scripts. The
+#     contamination judge reads these (cd $WORKSPACE && codex exec ...).
+#   - The agent's final_model arrives on a harbor task-declared shared
+#     volume mounted READ-ONLY at /mnt/model (see
+#     [[verifier.environment.volumes]] in task.toml) — the same
+#     per-trial volume the agent wrote to at
+#     /home/agent/workspace/final_model. The weights never ride the
+#     tar/host artifact path, and this container cannot modify them.
+#   - The agent's final_model is the only agent-produced input the
+#     verifier executes code against (via vllm). Bad weights are
+#     penalized by the eval score, not by tampering.
 
 TESTS="/tests"
 WORKSPACE="/home/agent/workspace"
+MODEL_DIR="/mnt/model"
 LOGS_DIR="/logs/verifier"
 
 mkdir -p "$LOGS_DIR"
@@ -34,6 +40,7 @@ mkdir -p "$LOGS_DIR"
 echo "=== PostTrainBench Verifier ==="
 echo "Tests dir: $TESTS"
 echo "Workspace: $WORKSPACE"
+echo "Model (read-only shared volume): $MODEL_DIR"
 echo "Logs dir: $LOGS_DIR"
 
 # Check GPU availability
@@ -41,11 +48,13 @@ echo ""
 echo "=== GPU Check ==="
 nvidia-smi 2>&1 | tee "$LOGS_DIR/gpu_check.txt" || echo "nvidia-smi failed"
 
-# Check if final_model exists in agent's workspace
+# Check the trained model on the shared volume. The mountpoint always
+# exists (harbor creates the volume), so also treat an EMPTY volume as
+# "no model" — that means the agent never wrote weights into final_model.
 echo ""
-echo "=== Checking final_model ==="
-if [ ! -d "$WORKSPACE/final_model" ]; then
-    echo "ERROR: final_model directory not found"
+echo "=== Checking final_model (at $MODEL_DIR) ==="
+if [ ! -d "$MODEL_DIR" ] || [ -z "$(ls -A "$MODEL_DIR" 2>/dev/null)" ]; then
+    echo "ERROR: final_model is missing or empty on the shared volume"
     ls -la "$WORKSPACE" > "$LOGS_DIR/workspace_listing.txt" 2>&1
     echo '{"error": "final_model not found", "accuracy": 0}' > "$LOGS_DIR/metrics.json"
     echo "0" > "$LOGS_DIR/reward.txt"
@@ -54,9 +63,9 @@ fi
 
 # Check if final_model has required files
 echo "Contents of final_model:"
-ls -la "$WORKSPACE/final_model" | tee "$LOGS_DIR/final_model_listing.txt"
+ls -la "$MODEL_DIR" | tee "$LOGS_DIR/final_model_listing.txt"
 
-if [ ! -f "$WORKSPACE/final_model/config.json" ]; then
+if [ ! -f "$MODEL_DIR/config.json" ]; then
     echo "ERROR: final_model/config.json not found - not a valid model"
     echo '{"error": "invalid model - no config.json", "accuracy": 0}' > "$LOGS_DIR/metrics.json"
     echo "0" > "$LOGS_DIR/reward.txt"
@@ -66,13 +75,13 @@ fi
 # Show model config
 echo ""
 echo "=== Model config.json ==="
-cat "$WORKSPACE/final_model/config.json" | head -50 | tee "$LOGS_DIR/model_config.txt"
+cat "$MODEL_DIR/config.json" | head -50 | tee "$LOGS_DIR/model_config.txt"
 
 # Check for tokenizer
 echo ""
 echo "=== Checking tokenizer files ==="
-ls -la "$WORKSPACE/final_model/"*token* 2>/dev/null || echo "No tokenizer files found with 'token' in name"
-ls -la "$WORKSPACE/final_model/"*.json 2>/dev/null || echo "No json files found"
+ls -la "$MODEL_DIR/"*token* 2>/dev/null || echo "No tokenizer files found with 'token' in name"
+ls -la "$MODEL_DIR/"*.json 2>/dev/null || echo "No json files found"
 
 # ============================================================
 # Read metadata for benchmark and model info — from /tests, NOT workspace,
@@ -152,8 +161,8 @@ fi
 #
 # evaluate.py is run from /tests (untamperable). Some evaluate.py scripts
 # (arenahardwriting, healthbench) `from evaluation_code.X import Y`, so
-# /tests must be cwd for the import to resolve. final_model lives in
-# the agent's workspace (only place it could exist), so --model-path is
+# /tests must be cwd for the import to resolve. final_model arrives on
+# the read-only shared volume at /mnt/model, so --model-path is
 # absolute.
 # ============================================================
 echo ""
@@ -187,7 +196,7 @@ run_evaluation() {
 
     set +e
     python3 "$TESTS/evaluate.py" \
-        --model-path "$WORKSPACE/final_model" \
+        --model-path "$MODEL_DIR" \
         --json-output-file "$LOGS_DIR/metrics.json" \
         --templates-dir "$TESTS/templates" \
         --limit -1 \


### PR DESCRIPTION
Builds on #8. The trained weights currently travel inside the single workspace
artifact: tarred in the agent env, downloaded to the host, re-uploaded into the
separate verifier env. That's the transfer path that died with tar exit code -1 /
empty stderr on multi-GB workspaces (2026-05-27 and 2026-06-27 trials, see the
task.toml comments) and forced the aggressive-excludes workaround — while still
carrying the multi-GB `final_model` through it.

## What this PR does

`final_model` becomes a Harbor **task-declared shared volume**
(`[[environment.volumes]]`, name `model`):

| Container | Mount path | Access |
|-----------|-----------|--------|
| Agent | `/home/agent/workspace/final_model` | read-write |
| Verifier | `/mnt/model` | **read-only** |

Harbor creates one volume per trial (`harbor-<trial>-model`), both containers
attach the same volume, and Harbor deletes it at trial cleanup. On Modal the
weights move as a [Modal Volume](https://modal.com/docs/guide/volumes), locally as
a Docker named volume — never through the tar/host path.

Consequences:

- The workspace artifact now carries **only the contamination-judge inputs** (the
  agent's source code) — `final_model` and stray weight-file patterns
  (`*.safetensors`, `*.pt`, `*.ckpt`, …) are added to the excludes, so the
  agent-side tar stays small regardless of model size.
- The verifier's copy of the weights is **read-only**: the verification phase
  cannot modify the evidence it grades. The mountpoint can't be deleted, renamed,
  or unmounted by the agent — worst case it empties its own deliverable, which
  test.sh scores as reward 0.
- Weights are no longer archived under `artifacts/workspace/final_model/` on the
  host. Run with harbor's `delete=False` if you need to inspect weights after a
  trial.

## Changes (4 files, +89/−45)

- `template/task.toml` — volume declarations on `[environment]` and
  `[verifier.environment]`; `final_model` + weight-file patterns added to the
  workspace-artifact excludes; comments updated (the "final_model is deliberately
  kept in the tar" rationale is retired).
- `template/tests/test.sh` — evaluate against read-only `/mnt/model`; an empty
  volume is treated as "no model" (the mountpoint always exists, so the old `-d`
  check alone would pass vacuously); tamper-resistance notes updated.
- `template/instruction.md` — one added line: `final_model` is a pre-created
  mounted volume; write into it (`save_pretrained("final_model")` / copy files
  in), don't delete or rename the folder itself. Avoids agents hitting a
  confusing `EBUSY` on the common `rm -rf final_model && mv checkpoint
  final_model` pattern.
- `README.md` — "Model Hand-off via Shared Volume" section + harbor install pin.

No changes to `adapter.py` or `tests/Dockerfile` — the existing separate-verifier
machinery (pristine `/tests` image, `_copy_eval_files`, judge-from-`/tests`) is
untouched.

## Validated end-to-end on Modal

Full trial of `posttrainbench-gsm8k-qwen3-1.7b` (claude-code / claude-sonnet-4-6,
agent budget reduced to 30 min for the test): **31m 9s total, zero exceptions,
reward 0.207**.

| Check | Result |
|---|---|
| Per-trial volume | `harbor-fb557659f03e-model` observed live on Modal mid-run; **deleted after cleanup** (`Volume.objects.list()` empty) |
| Agent phase (21m 21s) | Downloaded the base model, ran a real 2-epoch SFT, saved to `final_model` on the volume |
| Workspace artifact | **60 KB** (source code only — down from multi-GB with weights in the tar) |
| Verifier phase (9m 36s) | Own sandbox, vLLM loaded the model from read-only `/mnt/model`, full **1,319-sample** gsm8k eval |
| Score parity with the condor pipeline | `accuracy 0.2070 ± 0.011` vs the official Qwen3-1.7B base-model gsm8k score of **20.4** (leaderboard, HTCondor pipeline) — a **0.3-point difference, well inside the eval's own ±1.1 stderr**. The 30-min minimal SFT is expected to move the score barely, so landing this close to the base-model number is evidence the volume-fed eval reproduces the original pipeline's scoring, not an artifact of a different eval path |
| Cached re-run cost | Environment setup drops from 9m50s (cold image build) to **6 s** |
| Failure path (from an earlier run where the agent errored) | Verifier correctly scored the empty volume as reward 0 via the new missing/empty check |


## Dependency

Requires Harbor's task-declared shared volumes feature:
**harbor-framework/harbor#2603**. Until it lands:

    uv tool install "harbor @ git+https://github.com/surelyMersad/harbor.git@feat/task-shared-volumes"

The feature is capability-gated in Harbor (docker + modal direct-sandbox mode);
tasks fail fast with a clear error on unsupported providers. Upstream validation:
5,434 unit tests passing (40 new for this feature), plus live smoke trials on both
docker and modal.
