### PR TITLE
fix(harbor): keep reward output numeric

### DIFF
--- a/src/harbor_adapter/template/tests/test.sh
+++ b/src/harbor_adapter/template/tests/test.sh
@@ -276,6 +276,7 @@ if [ -f "$LOGS_DIR/metrics.json" ]; then
     cat "$LOGS_DIR/metrics.json"
 
     # Try to extract accuracy from the metrics JSON
+    PARSE_ERROR_LOG="$LOGS_DIR/metrics_parse_error.txt"
     ACCURACY=$(python3 -c "
 import json
 try:
@@ -297,7 +298,13 @@ try:
 except Exception as e:
     print(f'Error parsing metrics: {e}', file=__import__('sys').stderr)
     print(0)
-" 2>&1)
+" 2>"$PARSE_ERROR_LOG")
+
+    if [ -s "$PARSE_ERROR_LOG" ]; then
+        cat "$PARSE_ERROR_LOG" >&2
+    else
+        rm -f "$PARSE_ERROR_LOG"
+    fi
 
     echo "Accuracy: $ACCURACY"
     echo "$ACCURACY" > "$LOGS_DIR/reward.txt"


### PR DESCRIPTION
## Summary

The Harbor verifier captures the metric parser with `2>&1`, so a malformed `metrics.json` folds the parser diagnostic into `ACCURACY` and writes a non-numeric `reward.txt`.

This keeps stdout exclusively numeric while preserving parser diagnostics in `metrics_parse_error.txt` and the verifier stderr stream. A genuine score of zero and a parse failure remain distinguishable in verifier artifacts.

## Validation

```bash
bash -n src/harbor_adapter/template/tests/test.sh
git diff --check
```

Refs aisa-group/PostTrainBench#8